### PR TITLE
setting: macOS 접근성 권한 획득 로직 구현

### DIFF
--- a/Projects/MacReceiver/Sources/Accessibility/AccessibilityManager.swift
+++ b/Projects/MacReceiver/Sources/Accessibility/AccessibilityManager.swift
@@ -1,0 +1,84 @@
+import Foundation
+import ApplicationServices
+import AppKit
+import os
+
+private let logger = Logger(subsystem: "com.snap.receiver", category: "AccessibilityManager")
+
+/// 접근성 권한 관리자
+@MainActor
+public final class AccessibilityManager: ObservableObject {
+    // MARK: - Singleton
+
+    public static let shared = AccessibilityManager()
+
+    // MARK: - Published Properties
+
+    /// 접근성 권한 허용 여부
+    @Published public private(set) var isAccessibilityEnabled: Bool = false
+
+    // MARK: - Private Properties
+
+    private var pollingTask: Task<Void, Never>?
+
+    // MARK: - Initialization
+
+    private init() {
+        checkAccessibility()
+    }
+
+    // MARK: - Public Methods
+
+    /// 접근성 권한 상태 확인
+    public func checkAccessibility() {
+        isAccessibilityEnabled = AXIsProcessTrusted()
+        logger.info("Accessibility permission: \(self.isAccessibilityEnabled)")
+    }
+
+    /// 접근성 권한 요청 (시스템 다이얼로그 표시)
+    public func requestAccessibility() {
+        // kAXTrustedCheckOptionPrompt를 안전하게 사용
+        let promptKey = "AXTrustedCheckOptionPrompt" as CFString
+        let options = [promptKey: true] as CFDictionary
+        let trusted = AXIsProcessTrustedWithOptions(options)
+
+        if !trusted {
+            logger.info("Accessibility permission requested, starting polling...")
+            startPollingForPermission()
+        } else {
+            isAccessibilityEnabled = true
+        }
+    }
+
+    /// 시스템 환경설정 열기
+    public func openSystemPreferences() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") else {
+            return
+        }
+        NSWorkspace.shared.open(url)
+        startPollingForPermission()
+    }
+
+    // MARK: - Private Methods
+
+    /// 권한 획득까지 폴링
+    private func startPollingForPermission() {
+        stopPolling()
+
+        pollingTask = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+                checkAccessibility()
+                if isAccessibilityEnabled {
+                    logger.info("Accessibility permission granted")
+                    break
+                }
+            }
+        }
+    }
+
+    private func stopPolling() {
+        pollingTask?.cancel()
+        pollingTask = nil
+    }
+}

--- a/Projects/MacReceiver/Sources/MacReceiverApp.swift
+++ b/Projects/MacReceiver/Sources/MacReceiverApp.swift
@@ -46,10 +46,19 @@ struct MenuBarLabel: View {
 
 struct MenuBarView: View {
     @ObservedObject var serverManager: ServerManager
+    @ObservedObject private var accessibilityManager = AccessibilityManager.shared
     @Environment(\.openSettings) private var openSettings
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
+            // Accessibility Warning
+            if !accessibilityManager.isAccessibilityEnabled {
+                accessibilityWarningSection
+                    .padding()
+
+                Divider()
+            }
+
             // Status Section
             statusSection
                 .padding()
@@ -66,6 +75,37 @@ struct MenuBarView: View {
             actionsSection
         }
         .frame(width: 280)
+        .onAppear {
+            accessibilityManager.checkAccessibility()
+        }
+    }
+
+    @ViewBuilder
+    private var accessibilityWarningSection: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("접근성 권한 필요")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Text("입력 제어를 위해 권한이 필요합니다")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Button("허용") {
+                accessibilityManager.requestAccessibility()
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+        }
+        .padding(8)
+        .background(Color.orange.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
     }
 
     @ViewBuilder
@@ -207,6 +247,7 @@ struct SettingsView: View {
 
 struct GeneralSettingsView: View {
     @ObservedObject var serverManager: ServerManager
+    @ObservedObject private var accessibilityManager = AccessibilityManager.shared
 
     var body: some View {
         Form {
@@ -230,9 +271,36 @@ struct GeneralSettingsView: View {
                     Text(serverManager.connectedDevice ?? "없음")
                 }
             }
+
+            Section("권한") {
+                HStack {
+                    LabeledContent("접근성 권한") {
+                        HStack(spacing: 8) {
+                            Image(systemName: accessibilityManager.isAccessibilityEnabled
+                                  ? "checkmark.circle.fill"
+                                  : "exclamationmark.triangle.fill")
+                                .foregroundStyle(accessibilityManager.isAccessibilityEnabled ? .green : .orange)
+
+                            Text(accessibilityManager.isAccessibilityEnabled ? "허용됨" : "필요함")
+                                .foregroundStyle(accessibilityManager.isAccessibilityEnabled ? .green : .orange)
+                        }
+                    }
+
+                    if !accessibilityManager.isAccessibilityEnabled {
+                        Button("설정 열기") {
+                            accessibilityManager.openSystemPreferences()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                    }
+                }
+            }
         }
         .formStyle(.grouped)
         .padding()
+        .onAppear {
+            accessibilityManager.checkAccessibility()
+        }
     }
 }
 


### PR DESCRIPTION
## 🔮 작업 요약

macOS Receiver 앱이 CGEvent 및 Accessibility API를 사용하기 위한 권한 획득 로직을 구현했습니다.

## 🖥️ 상세 작업 내용

- [x] **AccessibilityManager 구현**: AXIsProcessTrusted로 권한 상태 확인
- [x] **권한 요청 다이얼로그**: AXIsProcessTrustedWithOptions로 시스템 다이얼로그 표시
- [x] **시스템 환경설정 열기**: 접근성 설정 페이지로 직접 이동
- [x] **비동기 폴링**: 권한 획득까지 1초 간격으로 상태 확인
- [x] **MenuBarView 경고 배너**: 권한 미허용 시 경고 UI 표시
- [x] **GeneralSettingsView 권한 섹션**: 권한 상태 및 설정 열기 버튼

## 📸 스크린샷

N/A (빌드 완료, 실제 디바이스 테스트 필요)

## 📌 이슈 및 특이사항

- **이슈**: Swift 6 strict concurrency로 인해 Timer 대신 Task 사용
- **특이사항**: kAXTrustedCheckOptionPrompt 상수가 concurrency-safe하지 않아 문자열 리터럴 사용

## 🚀 다음에 할 일

- #3: 트랙패드 (UDP) 구현
- #4: 키보드 입력 (TCP) 구현

Close #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)