### PR TITLE
feat: 트랙패드 (UDP) 구현

### DIFF
--- a/Projects/App/Sources/Features/App/AppFeature.swift
+++ b/Projects/App/Sources/Features/App/AppFeature.swift
@@ -6,6 +6,7 @@ public struct AppFeature {
     @ObservableState
     public struct State: Equatable {
         public var connection: ConnectionFeature.State = .init()
+        public var trackpad: TrackpadFeature.State = .init()
         public var selectedTab: Tab = .essentials
         public var isOnboarded: Bool = false
         public var isConnectionSheetPresented: Bool = false
@@ -39,6 +40,7 @@ public struct AppFeature {
 
     public enum Action {
         case connection(ConnectionFeature.Action)
+        case trackpad(TrackpadFeature.Action)
         case settings(SettingsFeature.Action)
         case tabSelected(Tab)
         case onAppear
@@ -54,6 +56,10 @@ public struct AppFeature {
     public var body: some ReducerOf<Self> {
         Scope(state: \.connection, action: \.connection) {
             ConnectionFeature()
+        }
+
+        Scope(state: \.trackpad, action: \.trackpad) {
+            TrackpadFeature()
         }
 
         Scope(state: \.settings, action: \.settings) {
@@ -97,6 +103,9 @@ public struct AppFeature {
                 return .none
 
             case .connection:
+                return .none
+
+            case .trackpad:
                 return .none
 
             case .settings:

--- a/Projects/App/Sources/Features/Trackpad/TrackpadFeature.swift
+++ b/Projects/App/Sources/Features/Trackpad/TrackpadFeature.swift
@@ -1,0 +1,169 @@
+import ComposableArchitecture
+import CoreGraphics
+import Shared
+
+@Reducer
+public struct TrackpadFeature {
+    @ObservableState
+    public struct State: Equatable {
+        public var mode: InputMode = .trackpad
+        public var isTouching: Bool = false
+        public var lastTouchPosition: CGPoint = .zero
+        public var sensitivity: Double = 1.0
+        public var scrollSensitivity: Double = 1.0
+        public var isNaturalScrolling: Bool = true
+        public var isTapToClick: Bool = true
+
+        public init() {}
+    }
+
+    public enum InputMode: String, CaseIterable, Sendable {
+        case trackpad
+        case laser
+
+        public var title: String {
+            switch self {
+            case .trackpad: return "Trackpad"
+            case .laser: return "Laser"
+            }
+        }
+    }
+
+    public enum Action: Equatable, Sendable {
+        // Mode
+        case modeChanged(InputMode)
+
+        // Touch Events
+        case touchBegan(CGPoint)
+        case touchMoved(CGPoint)
+        case touchEnded
+
+        // Gestures
+        case tapped
+        case doubleTapped
+        case twoFingerTapped
+        case scrolled(deltaX: CGFloat, deltaY: CGFloat)
+
+        // Click Buttons
+        case leftClickPressed
+        case leftClickReleased
+        case rightClickPressed
+        case rightClickReleased
+
+        // Quick Actions
+        case spotlightPressed
+        case missionControlPressed
+
+        // Settings
+        case updateSettings(
+            sensitivity: Double,
+            scrollSensitivity: Double,
+            isNaturalScrolling: Bool,
+            isTapToClick: Bool
+        )
+    }
+
+    @Dependency(\.connectionClient) var connectionClient
+
+    public init() {}
+
+    public var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            let client = connectionClient
+
+            switch action {
+            case .modeChanged(let mode):
+                state.mode = mode
+                return .none
+
+            case .touchBegan(let position):
+                state.isTouching = true
+                state.lastTouchPosition = position
+                return .none
+
+            case .touchMoved(let position):
+                guard state.isTouching else { return .none }
+
+                let deltaX = Float(position.x - state.lastTouchPosition.x) * Float(state.sensitivity)
+                let deltaY = Float(position.y - state.lastTouchPosition.y) * Float(state.sensitivity)
+                state.lastTouchPosition = position
+
+                return .run { _ in
+                    await client.sendMouseMove(deltaX, deltaY)
+                }
+
+            case .touchEnded:
+                state.isTouching = false
+                return .none
+
+            case .tapped:
+                guard state.isTapToClick else { return .none }
+                return .run { _ in
+                    await client.sendMouseClick(.left, .click)
+                }
+
+            case .doubleTapped:
+                return .run { _ in
+                    await client.sendMouseClick(.left, .double)
+                }
+
+            case .twoFingerTapped:
+                return .run { _ in
+                    await client.sendMouseClick(.right, .click)
+                }
+
+            case .scrolled(let deltaX, let deltaY):
+                let scrollX = Float(deltaX) * Float(state.scrollSensitivity)
+                let scrollY: Float
+                if state.isNaturalScrolling {
+                    scrollY = Float(deltaY) * Float(state.scrollSensitivity)
+                } else {
+                    scrollY = -Float(deltaY) * Float(state.scrollSensitivity)
+                }
+
+                return .run { _ in
+                    await client.sendScroll(scrollX, scrollY, false)
+                }
+
+            case .leftClickPressed:
+                return .run { _ in
+                    await client.sendMouseClick(.left, .down)
+                }
+
+            case .leftClickReleased:
+                return .run { _ in
+                    await client.sendMouseClick(.left, .up)
+                }
+
+            case .rightClickPressed:
+                return .run { _ in
+                    await client.sendMouseClick(.right, .down)
+                }
+
+            case .rightClickReleased:
+                return .run { _ in
+                    await client.sendMouseClick(.right, .up)
+                }
+
+            case .spotlightPressed:
+                // Cmd + Space
+                return .run { _ in
+                    await client.sendKeyCombo([49], 0x08) // Space with Command
+                }
+
+            case .missionControlPressed:
+                // Control + Up Arrow (Mission Control)
+                return .run { _ in
+                    await client.sendKeyCombo([126], 0x02) // Up Arrow with Control
+                }
+
+            case .updateSettings(let sensitivity, let scrollSensitivity, let isNaturalScrolling, let isTapToClick):
+                state.sensitivity = sensitivity
+                state.scrollSensitivity = scrollSensitivity
+                state.isNaturalScrolling = isNaturalScrolling
+                state.isTapToClick = isTapToClick
+                return .none
+            }
+        }
+    }
+}

--- a/Projects/App/Sources/Features/Trackpad/TrackpadView.swift
+++ b/Projects/App/Sources/Features/Trackpad/TrackpadView.swift
@@ -1,0 +1,278 @@
+import ComposableArchitecture
+import SwiftUI
+
+public struct TrackpadView: View {
+    @Bindable var store: StoreOf<TrackpadFeature>
+
+    public init(store: StoreOf<TrackpadFeature>) {
+        self.store = store
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            // Mode Toggle
+            modeToggle
+                .padding()
+
+            // Main Content
+            if store.mode == .trackpad {
+                trackpadContent
+            } else {
+                laserContent
+            }
+
+            // Quick Actions
+            quickActions
+                .padding()
+        }
+        .background(Color(.systemBackground))
+    }
+
+    // MARK: - Mode Toggle
+
+    @ViewBuilder
+    private var modeToggle: some View {
+        HStack(spacing: 0) {
+            ForEach(TrackpadFeature.InputMode.allCases, id: \.self) { mode in
+                Button {
+                    store.send(.modeChanged(mode))
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: mode == .trackpad ? "hand.point.up.left" : "scope")
+                            .font(.system(size: 14, weight: .medium))
+                        Text(mode.title)
+                            .font(.system(size: 14, weight: .semibold))
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+                    .background(store.mode == mode ? Color(.systemGray5) : Color.clear)
+                    .foregroundStyle(store.mode == mode ? .primary : .secondary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .background(Color(.systemGray6))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+
+    // MARK: - Trackpad Content
+
+    @ViewBuilder
+    private var trackpadContent: some View {
+        VStack(spacing: 16) {
+            // Touch Area
+            TrackpadTouchArea(store: store)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            // Click Buttons
+            HStack(spacing: 16) {
+                // Left Click
+                ClickButton(label: "L", isPrimary: true) {
+                    store.send(.leftClickPressed)
+                } onRelease: {
+                    store.send(.leftClickReleased)
+                }
+
+                // Right Click
+                ClickButton(label: "R", isPrimary: false) {
+                    store.send(.rightClickPressed)
+                } onRelease: {
+                    store.send(.rightClickReleased)
+                }
+            }
+            .frame(height: 60)
+            .padding(.horizontal)
+        }
+    }
+
+    // MARK: - Laser Content (Placeholder)
+
+    @ViewBuilder
+    private var laserContent: some View {
+        VStack(spacing: 20) {
+            Spacer()
+
+            Image(systemName: "scope")
+                .font(.system(size: 80))
+                .foregroundStyle(.red.opacity(0.5))
+
+            Text("Laser Mode")
+                .font(.title2)
+                .fontWeight(.semibold)
+
+            Text("Coming Soon")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Quick Actions
+
+    @ViewBuilder
+    private var quickActions: some View {
+        HStack(spacing: 16) {
+            QuickActionButton(
+                icon: "magnifyingglass",
+                label: "Spotlight"
+            ) {
+                store.send(.spotlightPressed)
+            }
+
+            QuickActionButton(
+                icon: "rectangle.3.group",
+                label: "Mission Control"
+            ) {
+                store.send(.missionControlPressed)
+            }
+        }
+    }
+}
+
+// MARK: - Trackpad Touch Area
+
+struct TrackpadTouchArea: View {
+    let store: StoreOf<TrackpadFeature>
+
+    var body: some View {
+        GeometryReader { _ in
+            ZStack {
+                // Background
+                RoundedRectangle(cornerRadius: 20)
+                    .fill(Color(.systemGray6))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 20)
+                            .strokeBorder(Color(.systemGray4), lineWidth: 1)
+                    )
+
+                // Watermark
+                Text("TRACKPAD")
+                    .font(.system(size: 32, weight: .black))
+                    .foregroundStyle(.quaternary)
+                    .tracking(8)
+
+                // Touch indicator
+                if store.isTouching {
+                    Circle()
+                        .fill(Color.blue.opacity(0.3))
+                        .frame(width: 80, height: 80)
+                        .blur(radius: 20)
+                        .position(store.lastTouchPosition)
+                }
+            }
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        if !store.isTouching {
+                            store.send(.touchBegan(value.location))
+                        } else {
+                            store.send(.touchMoved(value.location))
+                        }
+                    }
+                    .onEnded { _ in
+                        store.send(.touchEnded)
+                    }
+            )
+            .simultaneousGesture(
+                TapGesture()
+                    .onEnded {
+                        store.send(.tapped)
+                    }
+            )
+            .simultaneousGesture(
+                TapGesture(count: 2)
+                    .onEnded {
+                        store.send(.doubleTapped)
+                    }
+            )
+            .highPriorityGesture(
+                MagnifyGesture()
+                    .onChanged { value in
+                        // Two-finger scroll approximation
+                        let delta = Float(value.magnification - 1) * 10
+                        store.send(.scrolled(deltaX: 0, deltaY: CGFloat(delta)))
+                    }
+            )
+        }
+        .padding(.horizontal)
+    }
+}
+
+// MARK: - Click Button
+
+struct ClickButton: View {
+    let label: String
+    let isPrimary: Bool
+    let onPress: () -> Void
+    let onRelease: () -> Void
+
+    @State private var isPressed = false
+
+    var body: some View {
+        Text(label)
+            .font(.system(size: 18, weight: .bold))
+            .foregroundStyle(isPrimary ? .blue : .secondary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(isPressed ? Color(.systemGray4) : Color(.systemGray6))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16)
+                            .strokeBorder(Color(.systemGray4), lineWidth: 1)
+                    )
+            )
+            .scaleEffect(isPressed ? 0.95 : 1.0)
+            .animation(.easeInOut(duration: 0.1), value: isPressed)
+            .onLongPressGesture(
+                minimumDuration: .infinity,
+                pressing: { pressing in
+                    isPressed = pressing
+                    if pressing {
+                        onPress()
+                    } else {
+                        onRelease()
+                    }
+                },
+                perform: {}
+            )
+    }
+}
+
+// MARK: - Quick Action Button
+
+struct QuickActionButton: View {
+    let icon: String
+    let label: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 8) {
+                Image(systemName: icon)
+                    .font(.system(size: 24))
+                    .foregroundStyle(.primary)
+
+                Text(label)
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .textCase(.uppercase)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 16)
+            .background(Color(.systemGray6))
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    TrackpadView(
+        store: Store(initialState: TrackpadFeature.State()) {
+            TrackpadFeature()
+        }
+    )
+}

--- a/Projects/App/Sources/Views/AppView.swift
+++ b/Projects/App/Sources/Views/AppView.swift
@@ -16,7 +16,7 @@ public struct AppView: View {
 
                 // Main Content
                 TabView(selection: $store.selectedTab.sending(\.tabSelected)) {
-                    EssentialsTabView()
+                    TrackpadView(store: store.scope(state: \.trackpad, action: \.trackpad))
                         .tag(AppFeature.Tab.essentials)
                         .tabItem {
                             Label(
@@ -209,26 +209,6 @@ struct ConnectionStatusBar: View {
 }
 
 // MARK: - Tab Placeholder Views
-
-struct EssentialsTabView: View {
-    var body: some View {
-        VStack(spacing: 20) {
-            Image(systemName: "hand.tap")
-                .font(.system(size: 60))
-                .foregroundStyle(.blue)
-
-            Text("Essentials")
-                .font(.title2)
-                .fontWeight(.semibold)
-
-            Text("Trackpad, Keyboard, Media Controls")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(.systemBackground))
-    }
-}
 
 struct ProductivityTabView: View {
     var body: some View {


### PR DESCRIPTION
## 🔮 작업 요약

iOS 터치 제스처를 macOS 마우스 이벤트로 변환하는 Smart Trackpad 기능을 구현했습니다.

## 🖥️ 상세 작업 내용

- [x] **TrackpadFeature (TCA Reducer)**
  - InputMode: trackpad/laser 모드
  - 터치 이벤트 처리 (touchBegan, touchMoved, touchEnded)
  - 제스처 지원 (tap, doubleTap, twoFingerTap, scroll)
  - 클릭 버튼 (left/right, down/up)
  - 단축키 (Spotlight, Mission Control)

- [x] **TrackpadView (SwiftUI)**
  - 모드 토글 UI
  - 터치 영역 (드래그 제스처)
  - L/R 클릭 버튼
  - 단축 버튼 UI
  - 시각적 피드백

- [x] **AppFeature 통합**
  - TrackpadFeature Scope 연결
  - EssentialsTabView → TrackpadView 교체

## 📸 스크린샷

N/A (시뮬레이터/실제 디바이스 테스트 필요)

## 📌 이슈 및 특이사항

- **이슈**: Swift 6 concurrency로 인해 connectionClient를 로컬 변수로 복사하여 사용
- **특이사항**: Laser 모드는 placeholder로 구현 (추후 gyroscope 연동 예정)

## 🚀 다음에 할 일

- #4: 키보드 입력 (TCP) 구현
- 2손가락 스크롤 개선 (현재 MagnifyGesture 사용)
- 관성 스크롤 (Inertia) 구현

Close #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)