### PR TITLE
[Feat]: Siri 원격 호출 기능 구현

### DIFF
--- a/Projects/App/Sources/Features/App/AppFeature.swift
+++ b/Projects/App/Sources/Features/App/AppFeature.swift
@@ -9,6 +9,7 @@ public struct AppFeature {
         public var trackpad: TrackpadFeature.State = .init()
         public var keyboard: KeyboardFeature.State = .init()
         public var media: MediaFeature.State = .init()
+        public var productivity: ProductivityFeature.State = .init()
         public var selectedTab: Tab = .trackpad
         public var isOnboarded: Bool = false
         public var isConnectionSheetPresented: Bool = false
@@ -48,6 +49,7 @@ public struct AppFeature {
         case trackpad(TrackpadFeature.Action)
         case keyboard(KeyboardFeature.Action)
         case media(MediaFeature.Action)
+        case productivity(ProductivityFeature.Action)
         case settings(SettingsFeature.Action)
         case tabSelected(Tab)
         case onAppear
@@ -75,6 +77,10 @@ public struct AppFeature {
 
         Scope(state: \.media, action: \.media) {
             MediaFeature()
+        }
+
+        Scope(state: \.productivity, action: \.productivity) {
+            ProductivityFeature()
         }
 
         Scope(state: \.settings, action: \.settings) {
@@ -127,6 +133,9 @@ public struct AppFeature {
                 return .none
 
             case .media:
+                return .none
+
+            case .productivity:
                 return .none
 
             case .settings:

--- a/Projects/App/Sources/Features/Productivity/ProductivityFeature.swift
+++ b/Projects/App/Sources/Features/Productivity/ProductivityFeature.swift
@@ -1,0 +1,57 @@
+import ComposableArchitecture
+import Shared
+
+@Reducer
+public struct ProductivityFeature {
+    @ObservableState
+    public struct State: Equatable {
+        public var isSiriActive: Bool = false
+    }
+
+    public enum Action: Equatable, Sendable {
+        // Siri
+        case siriTapped
+        case siriLongPressStarted
+        case siriLongPressEnded
+        case dictationTapped(String)
+    }
+
+    @Dependency(\.connectionClient) var connectionClient
+
+    public init() {}
+
+    public var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            let client = connectionClient
+
+            switch action {
+            case .siriTapped:
+                state.isSiriActive.toggle()
+                let isActive = state.isSiriActive
+                return .run { _ in
+                    await client.sendSiriCommand(
+                        isActive ? .activate : .deactivate,
+                        ""
+                    )
+                }
+
+            case .siriLongPressStarted:
+                state.isSiriActive = true
+                return .run { _ in
+                    await client.sendSiriCommand(.activate, "")
+                }
+
+            case .siriLongPressEnded:
+                state.isSiriActive = false
+                return .run { _ in
+                    await client.sendSiriCommand(.deactivate, "")
+                }
+
+            case .dictationTapped(let text):
+                return .run { _ in
+                    await client.sendSiriCommand(.dictation, text)
+                }
+            }
+        }
+    }
+}

--- a/Projects/App/Sources/Features/Productivity/ProductivityView.swift
+++ b/Projects/App/Sources/Features/Productivity/ProductivityView.swift
@@ -1,0 +1,234 @@
+import ComposableArchitecture
+import SwiftUI
+
+public struct ProductivityView: View {
+    @Bindable var store: StoreOf<ProductivityFeature>
+
+    public init(store: StoreOf<ProductivityFeature>) {
+        self.store = store
+    }
+
+    public var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                // Siri Section
+                siriSection
+
+                // Window Snap Section (Placeholder)
+                windowSnapSection
+
+                // App Switcher Section (Placeholder)
+                appSwitcherSection
+            }
+            .padding()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemBackground))
+    }
+
+    // MARK: - Siri Section
+
+    @ViewBuilder
+    private var siriSection: some View {
+        VStack(spacing: 16) {
+            Text("Siri")
+                .font(.headline)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            HStack(spacing: 16) {
+                // Siri Button
+                SiriButton(isActive: store.isSiriActive) {
+                    store.send(.siriTapped)
+                }
+
+                // Dictation Button
+                Button {
+                    store.send(.dictationTapped(""))
+                } label: {
+                    VStack(spacing: 8) {
+                        Image(systemName: "keyboard")
+                            .font(.system(size: 24))
+                        Text("받아쓰기")
+                            .font(.caption)
+                    }
+                    .frame(width: 80, height: 80)
+                    .background(Color(.secondarySystemBackground))
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+                }
+                .buttonStyle(.plain)
+
+                Spacer()
+            }
+        }
+        .padding()
+        .background(Color(.secondarySystemBackground).opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+
+    // MARK: - Window Snap Section
+
+    @ViewBuilder
+    private var windowSnapSection: some View {
+        VStack(spacing: 16) {
+            Text("윈도우 스냅")
+                .font(.headline)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            LazyVGrid(columns: [
+                GridItem(.flexible()),
+                GridItem(.flexible()),
+                GridItem(.flexible()),
+                GridItem(.flexible())
+            ], spacing: 12) {
+                WindowSnapButton(icon: "rectangle.lefthalf.filled", label: "왼쪽")
+                WindowSnapButton(icon: "rectangle.righthalf.filled", label: "오른쪽")
+                WindowSnapButton(icon: "rectangle.tophalf.filled", label: "상단")
+                WindowSnapButton(icon: "rectangle.bottomhalf.filled", label: "하단")
+                WindowSnapButton(icon: "arrow.up.left.and.arrow.down.right", label: "전체화면")
+                WindowSnapButton(icon: "rectangle.center.inset.filled", label: "가운데")
+                WindowSnapButton(icon: "rectangle.topthird.inset.filled", label: "좌상단")
+                WindowSnapButton(icon: "rectangle.bottomthird.inset.filled", label: "우하단")
+            }
+        }
+        .padding()
+        .background(Color(.secondarySystemBackground).opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+
+    // MARK: - App Switcher Section
+
+    @ViewBuilder
+    private var appSwitcherSection: some View {
+        VStack(spacing: 16) {
+            Text("앱 스위처")
+                .font(.headline)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            HStack {
+                Image(systemName: "square.stack.3d.up")
+                    .font(.system(size: 40))
+                    .foregroundStyle(.purple)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("앱 목록 불러오기")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                    Text("Mac에서 실행 중인 앱 목록")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Button("불러오기") {
+                    // TODO: Request app list
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+        }
+        .padding()
+        .background(Color(.secondarySystemBackground).opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+}
+
+// MARK: - Siri Button
+
+struct SiriButton: View {
+    let isActive: Bool
+    let action: () -> Void
+
+    @State private var isPulsing = false
+
+    var body: some View {
+        Button(action: action) {
+            ZStack {
+                // Glow effect when active
+                if isActive {
+                    Circle()
+                        .fill(
+                            RadialGradient(
+                                colors: [
+                                    Color.purple.opacity(0.4),
+                                    Color.pink.opacity(0.2),
+                                    Color.clear
+                                ],
+                                center: .center,
+                                startRadius: 30,
+                                endRadius: 60
+                            )
+                        )
+                        .frame(width: 120, height: 120)
+                        .scaleEffect(isPulsing ? 1.2 : 1.0)
+                }
+
+                // Main button
+                Circle()
+                    .fill(
+                        LinearGradient(
+                            colors: isActive
+                                ? [Color.purple, Color.pink, Color.orange]
+                                : [Color(.systemGray4), Color(.systemGray5)],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .frame(width: 80, height: 80)
+                    .shadow(
+                        color: isActive ? Color.purple.opacity(0.5) : Color.clear,
+                        radius: 10
+                    )
+
+                // Icon
+                Image(systemName: "waveform.circle.fill")
+                    .font(.system(size: 36))
+                    .foregroundStyle(.white)
+                    .symbolEffect(.variableColor.iterative, isActive: isActive)
+            }
+        }
+        .buttonStyle(.plain)
+        .onChange(of: isActive) { _, newValue in
+            if newValue {
+                withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
+                    isPulsing = true
+                }
+            } else {
+                isPulsing = false
+            }
+        }
+    }
+}
+
+// MARK: - Window Snap Button
+
+struct WindowSnapButton: View {
+    let icon: String
+    let label: String
+
+    var body: some View {
+        Button {
+            // TODO: Send window snap command
+        } label: {
+            VStack(spacing: 6) {
+                Image(systemName: icon)
+                    .font(.system(size: 20))
+                Text(label)
+                    .font(.caption2)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 60)
+            .background(Color(.tertiarySystemBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    ProductivityView(
+        store: Store(initialState: ProductivityFeature.State()) {
+            ProductivityFeature()
+        }
+    )
+}

--- a/Projects/App/Sources/Services/ConnectionClient.swift
+++ b/Projects/App/Sources/Services/ConnectionClient.swift
@@ -22,6 +22,7 @@ public struct ConnectionClient: Sendable {
     public var sendWindowSnap: @Sendable (WindowSnap.Position) async -> Void
     public var requestAppList: @Sendable () async -> Void
     public var sendAppFocus: @Sendable (String, UInt32) async -> Void
+    public var sendSiriCommand: @Sendable (SiriCommand.Action, String) async -> Void
 }
 
 // MARK: - Events
@@ -77,7 +78,8 @@ extension ConnectionClient: DependencyKey {
             sendMediaControl: { cmd, vol in await actor.sendMediaControl(command: cmd, volume: vol) },
             sendWindowSnap: { pos in await actor.sendWindowSnap(position: pos) },
             requestAppList: { await actor.requestAppList() },
-            sendAppFocus: { bundleID, pid in await actor.sendAppFocus(bundleID: bundleID, pid: pid) }
+            sendAppFocus: { bundleID, pid in await actor.sendAppFocus(bundleID: bundleID, pid: pid) },
+            sendSiriCommand: { action, text in await actor.sendSiriCommand(action: action, text: text) }
         )
     }
 
@@ -95,7 +97,8 @@ extension ConnectionClient: DependencyKey {
             sendMediaControl: { _, _ in },
             sendWindowSnap: { _ in },
             requestAppList: {},
-            sendAppFocus: { _, _ in }
+            sendAppFocus: { _, _ in },
+            sendSiriCommand: { _, _ in }
         )
     }
 }
@@ -202,6 +205,10 @@ private actor ConnectionActor: SnapClientDelegate, BonjourBrowserDelegate {
 
     func sendAppFocus(bundleID: String, pid: UInt32) {
         client?.sendAppFocus(bundleID: bundleID, pid: pid)
+    }
+
+    func sendSiriCommand(action: SiriCommand.Action, text: String) {
+        client?.sendSiriCommand(action: action, text: text)
     }
 
     // MARK: - SnapClientDelegate

--- a/Projects/App/Sources/Services/SnapClient.swift
+++ b/Projects/App/Sources/Services/SnapClient.swift
@@ -146,6 +146,14 @@ public final class SnapClient: @unchecked Sendable {
         tcpConnection?.send(focus, type: .appFocus)
     }
 
+    /// Siri 명령 전송 (TCP)
+    public func sendSiriCommand(action: SiriCommand.Action, text: String = "") {
+        guard isConnected else { return }
+
+        let command = SiriCommand(action: action, text: text)
+        tcpConnection?.send(command, type: .siriCommand)
+    }
+
     // MARK: - Private Methods
 
     private static func getDeviceID() -> String {

--- a/Projects/App/Sources/Views/AppView.swift
+++ b/Projects/App/Sources/Views/AppView.swift
@@ -43,7 +43,7 @@ public struct AppView: View {
                             )
                         }
 
-                    ProductivityTabView()
+                    ProductivityView(store: store.scope(state: \.productivity, action: \.productivity))
                         .tag(AppFeature.Tab.productivity)
                         .tabItem {
                             Label(

--- a/Projects/MacReceiver/Sources/MacReceiverApp.swift
+++ b/Projects/MacReceiver/Sources/MacReceiverApp.swift
@@ -439,6 +439,10 @@ final class ServerManager: ObservableObject {
             // TODO: Type text
             logPacket("VoiceText: \(voice.text)")
 
+        case .siriCommand(let command, _):
+            SiriController.shared.execute(command: command)
+            logPacket("SiriCommand: \(command.action)")
+
         default:
             break
         }

--- a/Projects/MacReceiver/Sources/Server/SiriController.swift
+++ b/Projects/MacReceiver/Sources/Server/SiriController.swift
@@ -1,0 +1,112 @@
+import AppKit
+import Foundation
+import Shared
+
+/// Siri 컨트롤러
+/// AppleScript를 사용하여 Siri를 제어합니다.
+@MainActor
+public final class SiriController {
+    public static let shared = SiriController()
+
+    private init() {}
+
+    // MARK: - Public Methods
+
+    /// Siri 명령 실행
+    public func execute(command: SiriCommand) {
+        switch command.action {
+        case .activate:
+            activateSiri()
+        case .deactivate:
+            deactivateSiri()
+        case .dictation:
+            startDictation(text: command.text)
+        }
+    }
+
+    // MARK: - Siri Control
+
+    /// Siri 활성화
+    private func activateSiri() {
+        let script = """
+            tell application "Siri" to activate
+        """
+        runAppleScript(script)
+    }
+
+    /// Siri 비활성화
+    private func deactivateSiri() {
+        // Escape 키를 눌러 Siri 종료
+        sendKeyEvent(keyCode: 53) // Escape
+
+        // 또는 AppleScript로 Siri 종료
+        let script = """
+            tell application "Siri" to quit
+        """
+        runAppleScript(script)
+    }
+
+    /// 받아쓰기 모드 시작
+    private func startDictation(text: String) {
+        // fn 키를 두 번 눌러 받아쓰기 활성화
+        // macOS에서 받아쓰기는 fn fn (두 번 연속)으로 활성화됩니다
+        // 키 코드: fn = 63
+
+        // fn key down
+        sendKeyEvent(keyCode: 63, keyDown: true)
+        sendKeyEvent(keyCode: 63, keyDown: false)
+
+        // 짧은 딜레이 후 다시 fn
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            self?.sendKeyEvent(keyCode: 63, keyDown: true)
+            self?.sendKeyEvent(keyCode: 63, keyDown: false)
+        }
+
+        // 텍스트가 있으면 타이핑 (받아쓰기 대신 직접 입력)
+        if !text.isEmpty {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                self?.typeText(text)
+            }
+        }
+    }
+
+    // MARK: - Key Event Helper
+
+    private func sendKeyEvent(keyCode: CGKeyCode, keyDown: Bool = true) {
+        let event = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: keyDown)
+        event?.post(tap: .cghidEventTap)
+
+        if keyDown {
+            // Key up
+            let upEvent = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: false)
+            upEvent?.post(tap: .cghidEventTap)
+        }
+    }
+
+    /// 텍스트 직접 타이핑
+    private func typeText(_ text: String) {
+        for character in text {
+            let event = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true)
+            var char = UniChar(character.utf16.first ?? 0)
+            event?.keyboardSetUnicodeString(stringLength: 1, unicodeString: &char)
+            event?.post(tap: .cghidEventTap)
+
+            let upEvent = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false)
+            upEvent?.post(tap: .cghidEventTap)
+        }
+    }
+
+    // MARK: - AppleScript Helper
+
+    @discardableResult
+    private func runAppleScript(_ source: String) -> String? {
+        var error: NSDictionary?
+        if let script = NSAppleScript(source: source) {
+            let output = script.executeAndReturnError(&error)
+            if error == nil {
+                return output.stringValue
+            }
+        }
+        return nil
+    }
+}

--- a/Projects/Shared/Sources/Network/MessageType.swift
+++ b/Projects/Shared/Sources/Network/MessageType.swift
@@ -33,6 +33,8 @@ public enum MessageType: UInt8, Sendable {
     case presentation = 0x60
     /// 음성 텍스트
     case voiceText = 0x70
+    /// Siri 호출
+    case siriCommand = 0x71
 
     // MARK: - 시스템 메시지 (0x80 ~ 0xFF)
 

--- a/Projects/Shared/Sources/Network/PacketDecoder.swift
+++ b/Projects/Shared/Sources/Network/PacketDecoder.swift
@@ -28,6 +28,7 @@ public enum DecodedPacket: Sendable {
     case appFocus(AppFocus, header: PacketHeader)
     case presentation(Presentation, header: PacketHeader)
     case voiceText(VoiceText, header: PacketHeader)
+    case siriCommand(SiriCommand, header: PacketHeader)
 
     // System Messages
     case handshake(Handshake, header: PacketHeader)
@@ -52,6 +53,7 @@ public enum DecodedPacket: Sendable {
         case .appFocus: return .appFocus
         case .presentation: return .presentation
         case .voiceText: return .voiceText
+        case .siriCommand: return .siriCommand
         case .handshake: return .handshake
         case .heartbeat: return .heartbeat
         case .disconnect: return .disconnect
@@ -76,6 +78,7 @@ public enum DecodedPacket: Sendable {
              .appFocus(_, let header),
              .presentation(_, let header),
              .voiceText(_, let header),
+             .siriCommand(_, let header),
              .handshake(_, let header),
              .heartbeat(_, let header),
              .disconnect(_, let header),
@@ -152,6 +155,9 @@ public enum PacketDecoder {
             case .voiceText:
                 let message = try decoder.decode(VoiceText.self, from: payload)
                 return .voiceText(message, header: header)
+            case .siriCommand:
+                let message = try decoder.decode(SiriCommand.self, from: payload)
+                return .siriCommand(message, header: header)
 
             // System Messages
             case .handshake:

--- a/Projects/Shared/Sources/Protocol/ControlMessages.swift
+++ b/Projects/Shared/Sources/Protocol/ControlMessages.swift
@@ -78,3 +78,22 @@ public struct VoiceText: Codable, Sendable, Equatable {
         self.isFinal = isFinal
     }
 }
+
+// MARK: - SiriCommand
+
+/// Siri 호출 제어
+public struct SiriCommand: Codable, Sendable, Equatable {
+    public enum Action: Int, Codable, Sendable, CaseIterable {
+        case activate = 0     // Siri 활성화
+        case deactivate = 1   // Siri 비활성화
+        case dictation = 2    // 받아쓰기 모드
+    }
+
+    public var action: Action
+    public var text: String   // dictation 모드에서 전달할 텍스트
+
+    public init(action: Action = .activate, text: String = "") {
+        self.action = action
+        self.text = text
+    }
+}


### PR DESCRIPTION
## Summary
- MessageType에 `siriCommand` (0x71) 추가
- `SiriCommand` 프로토콜 메시지 구현 (activate/deactivate/dictation)
- macOS에 `SiriController` 구현 (AppleScript 기반 Siri 제어)
- iOS에 `ProductivityFeature`/`ProductivityView` 구현
  - Siri 버튼 (활성화 시 그라데이션 및 펄스 애니메이션)
  - 받아쓰기 버튼
  - 윈도우 스냅, 앱 스위처 UI 플레이스홀더

## Test plan
- [ ] iOS 앱에서 Productivity 탭으로 이동
- [ ] Siri 버튼 탭 시 Mac에서 Siri 활성화 확인
- [ ] 다시 탭 시 Siri 비활성화 확인
- [ ] 받아쓰기 버튼 기능 테스트

Close #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)