### PR TITLE
[Feat]: 윈도우 컨트롤러 (AXUIElement) 구현

### DIFF
--- a/Projects/App/Sources/Features/Productivity/ProductivityFeature.swift
+++ b/Projects/App/Sources/Features/Productivity/ProductivityFeature.swift
@@ -14,6 +14,9 @@ public struct ProductivityFeature {
         case siriLongPressStarted
         case siriLongPressEnded
         case dictationTapped(String)
+
+        // Window Snap
+        case windowSnapTapped(WindowSnap.Position)
     }
 
     @Dependency(\.connectionClient) var connectionClient
@@ -50,6 +53,11 @@ public struct ProductivityFeature {
             case .dictationTapped(let text):
                 return .run { _ in
                     await client.sendSiriCommand(.dictation, text)
+                }
+
+            case .windowSnapTapped(let position):
+                return .run { _ in
+                    await client.sendWindowSnap(position)
                 }
             }
         }

--- a/Projects/App/Sources/Features/Productivity/ProductivityView.swift
+++ b/Projects/App/Sources/Features/Productivity/ProductivityView.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import Shared
 import SwiftUI
 
 public struct ProductivityView: View {
@@ -80,14 +81,30 @@ public struct ProductivityView: View {
                 GridItem(.flexible()),
                 GridItem(.flexible())
             ], spacing: 12) {
-                WindowSnapButton(icon: "rectangle.lefthalf.filled", label: "왼쪽")
-                WindowSnapButton(icon: "rectangle.righthalf.filled", label: "오른쪽")
-                WindowSnapButton(icon: "rectangle.tophalf.filled", label: "상단")
-                WindowSnapButton(icon: "rectangle.bottomhalf.filled", label: "하단")
-                WindowSnapButton(icon: "arrow.up.left.and.arrow.down.right", label: "전체화면")
-                WindowSnapButton(icon: "rectangle.center.inset.filled", label: "가운데")
-                WindowSnapButton(icon: "rectangle.topthird.inset.filled", label: "좌상단")
-                WindowSnapButton(icon: "rectangle.bottomthird.inset.filled", label: "우하단")
+                WindowSnapButton(icon: "rectangle.lefthalf.filled", label: "왼쪽") {
+                    store.send(.windowSnapTapped(.leftHalf))
+                }
+                WindowSnapButton(icon: "rectangle.righthalf.filled", label: "오른쪽") {
+                    store.send(.windowSnapTapped(.rightHalf))
+                }
+                WindowSnapButton(icon: "rectangle.tophalf.filled", label: "상단") {
+                    store.send(.windowSnapTapped(.topHalf))
+                }
+                WindowSnapButton(icon: "rectangle.bottomhalf.filled", label: "하단") {
+                    store.send(.windowSnapTapped(.bottomHalf))
+                }
+                WindowSnapButton(icon: "arrow.up.left.and.arrow.down.right", label: "전체화면") {
+                    store.send(.windowSnapTapped(.fullScreen))
+                }
+                WindowSnapButton(icon: "rectangle.center.inset.filled", label: "가운데") {
+                    store.send(.windowSnapTapped(.center))
+                }
+                WindowSnapButton(icon: "rectangle.topthird.inset.filled", label: "좌상단") {
+                    store.send(.windowSnapTapped(.topLeft))
+                }
+                WindowSnapButton(icon: "rectangle.bottomthird.inset.filled", label: "우하단") {
+                    store.send(.windowSnapTapped(.bottomRight))
+                }
             }
         }
         .padding()
@@ -205,11 +222,10 @@ struct SiriButton: View {
 struct WindowSnapButton: View {
     let icon: String
     let label: String
+    let action: () -> Void
 
     var body: some View {
-        Button {
-            // TODO: Send window snap command
-        } label: {
+        Button(action: action) {
             VStack(spacing: 6) {
                 Image(systemName: icon)
                     .font(.system(size: 20))

--- a/Projects/MacReceiver/Sources/MacReceiverApp.swift
+++ b/Projects/MacReceiver/Sources/MacReceiverApp.swift
@@ -420,7 +420,7 @@ final class ServerManager: ObservableObject {
             logPacket("MediaControl: \(media.command)")
 
         case .windowSnap(let snap, _):
-            // TODO: Implement window snap
+            WindowController.shared.snap(to: snap.position)
             logPacket("WindowSnap: \(snap.position)")
 
         case .appListRequest:

--- a/Projects/MacReceiver/Sources/Server/WindowController.swift
+++ b/Projects/MacReceiver/Sources/Server/WindowController.swift
@@ -1,0 +1,190 @@
+import AppKit
+import ApplicationServices
+import Foundation
+import Shared
+
+/// 윈도우 컨트롤러
+/// AXUIElement를 사용하여 윈도우 크기/위치를 제어합니다.
+@MainActor
+public final class WindowController {
+    public static let shared = WindowController()
+
+    private init() {}
+
+    // MARK: - Public Methods
+
+    /// 윈도우 스냅 실행
+    public func snap(to position: WindowSnap.Position) {
+        guard let frontmostApp = NSWorkspace.shared.frontmostApplication,
+              let window = getFocusedWindow(for: frontmostApp) else {
+            return
+        }
+
+        guard let screen = NSScreen.main else { return }
+        let screenFrame = screen.visibleFrame
+
+        let targetFrame = calculateFrame(for: position, in: screenFrame)
+        setWindowFrame(window, to: targetFrame)
+    }
+
+    // MARK: - Private Methods
+
+    /// 앱의 포커스된 윈도우 가져오기
+    private func getFocusedWindow(for app: NSRunningApplication) -> AXUIElement? {
+        let appElement = AXUIElementCreateApplication(app.processIdentifier)
+
+        var focusedWindow: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(
+            appElement,
+            kAXFocusedWindowAttribute as CFString,
+            &focusedWindow
+        )
+
+        guard result == .success, let window = focusedWindow else {
+            // 포커스된 윈도우가 없으면 첫 번째 윈도우 시도
+            return getFirstWindow(for: appElement)
+        }
+
+        return (window as! AXUIElement)
+    }
+
+    /// 첫 번째 윈도우 가져오기
+    private func getFirstWindow(for appElement: AXUIElement) -> AXUIElement? {
+        var windowList: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(
+            appElement,
+            kAXWindowsAttribute as CFString,
+            &windowList
+        )
+
+        guard result == .success,
+              let windows = windowList as? [AXUIElement],
+              let firstWindow = windows.first else {
+            return nil
+        }
+
+        return firstWindow
+    }
+
+    /// 포지션에 따른 프레임 계산
+    private func calculateFrame(for position: WindowSnap.Position, in screenFrame: CGRect) -> CGRect {
+        let x = screenFrame.origin.x
+        let y = screenFrame.origin.y
+        let width = screenFrame.width
+        let height = screenFrame.height
+
+        switch position {
+        case .fullScreen:
+            return screenFrame
+
+        case .leftHalf:
+            return CGRect(x: x, y: y, width: width / 2, height: height)
+
+        case .rightHalf:
+            return CGRect(x: x + width / 2, y: y, width: width / 2, height: height)
+
+        case .topHalf:
+            return CGRect(x: x, y: y + height / 2, width: width, height: height / 2)
+
+        case .bottomHalf:
+            return CGRect(x: x, y: y, width: width, height: height / 2)
+
+        case .center:
+            let centerWidth = width * 0.6
+            let centerHeight = height * 0.7
+            return CGRect(
+                x: x + (width - centerWidth) / 2,
+                y: y + (height - centerHeight) / 2,
+                width: centerWidth,
+                height: centerHeight
+            )
+
+        case .topLeft:
+            return CGRect(x: x, y: y + height / 2, width: width / 2, height: height / 2)
+
+        case .topRight:
+            return CGRect(x: x + width / 2, y: y + height / 2, width: width / 2, height: height / 2)
+
+        case .bottomLeft:
+            return CGRect(x: x, y: y, width: width / 2, height: height / 2)
+
+        case .bottomRight:
+            return CGRect(x: x + width / 2, y: y, width: width / 2, height: height / 2)
+        }
+    }
+
+    /// 윈도우 프레임 설정
+    private func setWindowFrame(_ window: AXUIElement, to frame: CGRect) {
+        // 위치 설정
+        var position = CGPoint(x: frame.origin.x, y: frame.origin.y)
+        if let positionValue = AXValueCreate(.cgPoint, &position) {
+            AXUIElementSetAttributeValue(window, kAXPositionAttribute as CFString, positionValue)
+        }
+
+        // 크기 설정
+        var size = CGSize(width: frame.width, height: frame.height)
+        if let sizeValue = AXValueCreate(.cgSize, &size) {
+            AXUIElementSetAttributeValue(window, kAXSizeAttribute as CFString, sizeValue)
+        }
+    }
+
+    // MARK: - Window Info
+
+    /// 현재 윈도우 정보
+    public struct WindowInfo: Sendable {
+        public let title: String
+        public let appName: String
+        public let frame: CGRect
+    }
+
+    /// 현재 포커스된 윈도우 정보 가져오기
+    public func getFocusedWindowInfo() -> WindowInfo? {
+        guard let frontmostApp = NSWorkspace.shared.frontmostApplication,
+              let window = getFocusedWindow(for: frontmostApp) else {
+            return nil
+        }
+
+        let title = getWindowTitle(window) ?? "Unknown"
+        let appName = frontmostApp.localizedName ?? "Unknown"
+        let frame = getWindowFrame(window) ?? .zero
+
+        return WindowInfo(title: title, appName: appName, frame: frame)
+    }
+
+    /// 윈도우 타이틀 가져오기
+    private func getWindowTitle(_ window: AXUIElement) -> String? {
+        var titleValue: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(
+            window,
+            kAXTitleAttribute as CFString,
+            &titleValue
+        )
+
+        guard result == .success, let title = titleValue as? String else {
+            return nil
+        }
+
+        return title
+    }
+
+    /// 윈도우 프레임 가져오기
+    private func getWindowFrame(_ window: AXUIElement) -> CGRect? {
+        var positionValue: CFTypeRef?
+        var sizeValue: CFTypeRef?
+
+        AXUIElementCopyAttributeValue(window, kAXPositionAttribute as CFString, &positionValue)
+        AXUIElementCopyAttributeValue(window, kAXSizeAttribute as CFString, &sizeValue)
+
+        guard let posVal = positionValue, let sizeVal = sizeValue else {
+            return nil
+        }
+
+        var position = CGPoint.zero
+        var size = CGSize.zero
+
+        AXValueGetValue(posVal as! AXValue, .cgPoint, &position)
+        AXValueGetValue(sizeVal as! AXValue, .cgSize, &size)
+
+        return CGRect(origin: position, size: size)
+    }
+}


### PR DESCRIPTION
## Summary
- `WindowController.swift` 생성 (AXUIElement 기반 윈도우 제어)
- 10가지 스냅 포지션 구현:
  - 전체화면, 왼쪽/오른쪽 절반, 상단/하단 절반
  - 4분할 (좌상단, 우상단, 좌하단, 우하단)
  - 중앙 (화면의 60% x 70%)
- iOS `ProductivityView`의 윈도우 스냅 버튼 기능 연결
- 접근성 권한 필요 (기존 `AccessibilityManager` 활용)

## Test plan
- [ ] macOS에서 접근성 권한 허용
- [ ] iOS 앱에서 Productivity 탭 → 윈도우 스냅 버튼 탭
- [ ] Mac의 활성 윈도우가 해당 위치로 스냅되는지 확인
- [ ] 모든 10가지 포지션 테스트

Close #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)