### PR TITLE
[Design]: iOS 앱 HIG 준수 - 시스템 색상 및 접근성 적용

### DIFF
--- a/Projects/App/Sources/Features/Keyboard/KeyboardView.swift
+++ b/Projects/App/Sources/Features/Keyboard/KeyboardView.swift
@@ -35,10 +35,10 @@ public struct KeyboardView: View {
     // MARK: - Text Input Area
 
     private var textInputArea: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: 16) {
             TextField("Type here...", text: $store.inputText.sending(\.textChanged))
                 .textFieldStyle(.plain)
-                .font(.system(size: 18))
+                .font(.body)
                 .padding()
                 .background(Color(.secondarySystemBackground))
                 .clipShape(RoundedRectangle(cornerRadius: 12))
@@ -55,7 +55,7 @@ public struct KeyboardView: View {
                 store.send(.clearText)
             } label: {
                 Image(systemName: "xmark.circle.fill")
-                    .font(.system(size: 24))
+                    .font(.title2)
                     .foregroundStyle(Color(.tertiaryLabel))
             }
             .opacity(store.inputText.isEmpty ? 0 : 1)
@@ -140,14 +140,14 @@ public struct KeyboardView: View {
                 store.send(.spacePressed)
             } label: {
                 Text("Space")
-                    .font(.system(size: 14, weight: .medium))
+                    .font(.subheadline.weight(.medium))
                     .foregroundStyle(Color(.label))
                     .frame(maxWidth: .infinity)
                     .frame(height: 44)
                     .background(Color(.secondarySystemBackground))
-                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
                     .overlay(
-                        RoundedRectangle(cornerRadius: 10)
+                        RoundedRectangle(cornerRadius: 12)
                             .strokeBorder(Color(.separator), lineWidth: 1)
                     )
             }
@@ -159,12 +159,12 @@ public struct KeyboardView: View {
     // MARK: - Arrow Keys
 
     private var arrowKeys: some View {
-        VStack(spacing: 4) {
+        VStack(spacing: 8) {
             ArrowKeyButton(direction: .up) {
                 store.send(.arrowPressed(.up))
             }
 
-            HStack(spacing: 4) {
+            HStack(spacing: 8) {
                 ArrowKeyButton(direction: .left) {
                     store.send(.arrowPressed(.left))
                 }
@@ -196,10 +196,10 @@ struct ModifierKeyButton: View {
     var body: some View {
         VStack(spacing: 4) {
             Text(symbol)
-                .font(.system(size: 20, weight: .medium))
+                .font(.title3.weight(.medium))
 
             Text(label)
-                .font(.system(size: 10, weight: .medium))
+                .font(.caption2.weight(.medium))
         }
         .foregroundStyle(foregroundColor)
         .frame(maxWidth: .infinity)
@@ -276,18 +276,18 @@ struct SpecialKeyButton: View {
         Button(action: action) {
             VStack(spacing: 4) {
                 Image(systemName: icon)
-                    .font(.system(size: 16, weight: .medium))
+                    .font(.callout.weight(.medium))
 
                 Text(label)
-                    .font(.system(size: 10, weight: .medium))
+                    .font(.caption2.weight(.medium))
             }
             .foregroundStyle(Color(.label))
             .frame(maxWidth: .infinity)
             .frame(height: 56)
             .background(isPressed ? Color(.tertiarySystemFill) : Color(.secondarySystemBackground))
-            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
             .overlay(
-                RoundedRectangle(cornerRadius: 10)
+                RoundedRectangle(cornerRadius: 12)
                     .strokeBorder(Color(.separator), lineWidth: 1)
             )
             .scaleEffect(isPressed ? 0.95 : 1.0)
@@ -335,7 +335,7 @@ struct ArrowKeyButton: View {
     var body: some View {
         Button(action: action) {
             Image(systemName: iconName)
-                .font(.system(size: 20, weight: .semibold))
+                .font(.title3.weight(.semibold))
                 .foregroundStyle(Color(.label))
                 .frame(width: 56, height: 44)
                 .background(isPressed ? Color(.tertiarySystemFill) : Color(.secondarySystemBackground))

--- a/Projects/App/Sources/Features/Keyboard/KeyboardView.swift
+++ b/Projects/App/Sources/Features/Keyboard/KeyboardView.swift
@@ -29,7 +29,7 @@ public struct KeyboardView: View {
             arrowKeys
                 .padding()
         }
-        .background(Color.black)
+        .background(Color(.systemBackground))
     }
 
     // MARK: - Text Input Area
@@ -40,23 +40,26 @@ public struct KeyboardView: View {
                 .textFieldStyle(.plain)
                 .font(.system(size: 18))
                 .padding()
-                .background(Color.white.opacity(0.1))
+                .background(Color(.secondarySystemBackground))
                 .clipShape(RoundedRectangle(cornerRadius: 12))
                 .overlay(
                     RoundedRectangle(cornerRadius: 12)
-                        .strokeBorder(Color.white.opacity(0.2), lineWidth: 1)
+                        .strokeBorder(Color(.separator), lineWidth: 1)
                 )
-                .foregroundStyle(.white)
+                .foregroundStyle(Color(.label))
                 .focused($isTextFieldFocused)
+                .accessibilityLabel("텍스트 입력")
+                .accessibilityHint("Mac으로 보낼 텍스트를 입력하세요")
 
             Button {
                 store.send(.clearText)
             } label: {
                 Image(systemName: "xmark.circle.fill")
                     .font(.system(size: 24))
-                    .foregroundStyle(Color.white.opacity(0.5))
+                    .foregroundStyle(Color(.tertiaryLabel))
             }
             .opacity(store.inputText.isEmpty ? 0 : 1)
+            .accessibilityLabel("텍스트 지우기")
         }
     }
 
@@ -138,17 +141,18 @@ public struct KeyboardView: View {
             } label: {
                 Text("Space")
                     .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(Color(.label))
                     .frame(maxWidth: .infinity)
                     .frame(height: 44)
-                    .background(Color.white.opacity(0.1))
+                    .background(Color(.secondarySystemBackground))
                     .clipShape(RoundedRectangle(cornerRadius: 10))
                     .overlay(
                         RoundedRectangle(cornerRadius: 10)
-                            .strokeBorder(Color.white.opacity(0.15), lineWidth: 1)
+                            .strokeBorder(Color(.separator), lineWidth: 1)
                     )
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("스페이스 키")
         }
     }
 
@@ -231,28 +235,31 @@ struct ModifierKeyButton: View {
                     onDoubleTap()
                 }
         )
+        .accessibilityLabel("\(label) 키")
+        .accessibilityValue(isLocked ? "잠김" : (isActive ? "활성화" : "비활성화"))
+        .accessibilityHint("탭하여 토글, 더블탭하여 잠금")
     }
 
     private var foregroundColor: Color {
-        isActive ? .white : .gray
+        isActive ? Color(.label) : Color(.secondaryLabel)
     }
 
     private var backgroundColor: Color {
         if isLocked {
-            return Color.blue.opacity(0.3)
+            return Color.accentColor.opacity(0.2)
         } else if isActive {
-            return Color.white.opacity(0.15)
+            return Color(.tertiarySystemBackground)
         }
-        return Color.white.opacity(0.05)
+        return Color(.secondarySystemBackground)
     }
 
     private var borderColor: Color {
         if isLocked {
-            return .blue
+            return .accentColor
         } else if isActive {
-            return Color.white.opacity(0.2)
+            return Color(.separator)
         }
-        return Color.white.opacity(0.1)
+        return Color(.separator).opacity(0.5)
     }
 }
 
@@ -274,18 +281,19 @@ struct SpecialKeyButton: View {
                 Text(label)
                     .font(.system(size: 10, weight: .medium))
             }
-            .foregroundStyle(.white)
+            .foregroundStyle(Color(.label))
             .frame(maxWidth: .infinity)
             .frame(height: 56)
-            .background(Color.white.opacity(isPressed ? 0.15 : 0.08))
+            .background(isPressed ? Color(.tertiarySystemFill) : Color(.secondarySystemBackground))
             .clipShape(RoundedRectangle(cornerRadius: 10))
             .overlay(
                 RoundedRectangle(cornerRadius: 10)
-                    .strokeBorder(Color.white.opacity(0.1), lineWidth: 1)
+                    .strokeBorder(Color(.separator), lineWidth: 1)
             )
             .scaleEffect(isPressed ? 0.95 : 1.0)
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("\(label) 키")
         .pressEvents {
             withAnimation(.spring(response: 0.2, dampingFraction: 0.6)) {
                 isPressed = true
@@ -315,21 +323,31 @@ struct ArrowKeyButton: View {
         }
     }
 
+    private var accessibilityLabel: String {
+        switch direction {
+        case .up: return "위쪽 화살표"
+        case .down: return "아래쪽 화살표"
+        case .left: return "왼쪽 화살표"
+        case .right: return "오른쪽 화살표"
+        }
+    }
+
     var body: some View {
         Button(action: action) {
             Image(systemName: iconName)
                 .font(.system(size: 20, weight: .semibold))
-                .foregroundStyle(.white)
+                .foregroundStyle(Color(.label))
                 .frame(width: 56, height: 44)
-                .background(Color.white.opacity(isPressed ? 0.15 : 0.08))
+                .background(isPressed ? Color(.tertiarySystemFill) : Color(.secondarySystemBackground))
                 .clipShape(RoundedRectangle(cornerRadius: 8))
                 .overlay(
                     RoundedRectangle(cornerRadius: 8)
-                        .strokeBorder(Color.white.opacity(0.1), lineWidth: 1)
+                        .strokeBorder(Color(.separator), lineWidth: 1)
                 )
                 .scaleEffect(isPressed ? 0.95 : 1.0)
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
         .pressEvents {
             withAnimation(.spring(response: 0.2, dampingFraction: 0.6)) {
                 isPressed = true
@@ -348,5 +366,4 @@ struct ArrowKeyButton: View {
             KeyboardFeature()
         }
     )
-    .preferredColorScheme(.dark)
 }

--- a/Projects/App/Sources/Features/Media/MediaView.swift
+++ b/Projects/App/Sources/Features/Media/MediaView.swift
@@ -26,7 +26,7 @@ public struct MediaView: View {
             Spacer()
         }
         .padding()
-        .background(Color.black)
+        .background(Color(.systemBackground))
     }
 
     // MARK: - Now Playing Area
@@ -35,22 +35,23 @@ public struct MediaView: View {
         VStack(spacing: 16) {
             // Album Art Placeholder
             RoundedRectangle(cornerRadius: 16)
-                .fill(Color.white.opacity(0.1))
+                .fill(Color(.secondarySystemBackground))
                 .frame(width: 200, height: 200)
                 .overlay(
                     Image(systemName: "music.note")
                         .font(.system(size: 60))
-                        .foregroundStyle(Color.white.opacity(0.3))
+                        .foregroundStyle(Color(.tertiaryLabel))
                 )
+                .accessibilityLabel("앨범 아트")
 
             VStack(spacing: 4) {
                 Text("Not Playing")
                     .font(.system(size: 20, weight: .semibold))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(Color(.label))
 
                 Text("Select a track to play")
                     .font(.system(size: 14))
-                    .foregroundStyle(Color.white.opacity(0.6))
+                    .foregroundStyle(Color(.secondaryLabel))
             }
         }
     }
@@ -62,7 +63,8 @@ public struct MediaView: View {
             // Previous Track
             MediaButton(
                 icon: "backward.fill",
-                size: 28
+                size: 28,
+                accessibilityLabel: "이전 트랙"
             ) {
                 store.send(.previousTrackTapped)
             }
@@ -71,7 +73,8 @@ public struct MediaView: View {
             MediaButton(
                 icon: store.isPlaying ? "pause.fill" : "play.fill",
                 size: 40,
-                isPrimary: true
+                isPrimary: true,
+                accessibilityLabel: store.isPlaying ? "일시정지" : "재생"
             ) {
                 store.send(.playPauseTapped)
             }
@@ -79,7 +82,8 @@ public struct MediaView: View {
             // Next Track
             MediaButton(
                 icon: "forward.fill",
-                size: 28
+                size: 28,
+                accessibilityLabel: "다음 트랙"
             ) {
                 store.send(.nextTrackTapped)
             }
@@ -97,15 +101,18 @@ public struct MediaView: View {
                 } label: {
                     Image(systemName: "speaker.fill")
                         .font(.system(size: 16))
-                        .foregroundStyle(Color.white.opacity(0.7))
+                        .foregroundStyle(Color(.secondaryLabel))
                 }
+                .accessibilityLabel("볼륨 줄이기")
 
                 // Volume Slider
                 Slider(
                     value: $store.volume.sending(\.volumeChanged),
                     in: 0...1
                 )
-                .tint(.white)
+                .tint(.accentColor)
+                .accessibilityLabel("볼륨")
+                .accessibilityValue("\(Int(store.volume * 100))%")
 
                 // Volume Up
                 Button {
@@ -113,8 +120,9 @@ public struct MediaView: View {
                 } label: {
                     Image(systemName: "speaker.wave.3.fill")
                         .font(.system(size: 16))
-                        .foregroundStyle(Color.white.opacity(0.7))
+                        .foregroundStyle(Color(.secondaryLabel))
                 }
+                .accessibilityLabel("볼륨 높이기")
             }
             .padding(.horizontal)
 
@@ -129,12 +137,17 @@ public struct MediaView: View {
                     Text(store.isMuted ? "Unmute" : "Mute")
                         .font(.system(size: 14, weight: .medium))
                 }
-                .foregroundStyle(store.isMuted ? .red : Color.white.opacity(0.7))
+                .foregroundStyle(store.isMuted ? .red : Color(.secondaryLabel))
                 .padding(.horizontal, 20)
                 .padding(.vertical, 10)
-                .background(Color.white.opacity(0.1))
+                .background(Color(.secondarySystemBackground))
                 .clipShape(Capsule())
+                .overlay(
+                    Capsule()
+                        .strokeBorder(Color(.separator), lineWidth: 1)
+                )
             }
+            .accessibilityLabel(store.isMuted ? "음소거 해제" : "음소거")
         }
     }
 }
@@ -145,6 +158,7 @@ struct MediaButton: View {
     let icon: String
     let size: CGFloat
     var isPrimary: Bool = false
+    var accessibilityLabel: String = ""
     let action: () -> Void
 
     @State private var isPressed = false
@@ -153,17 +167,18 @@ struct MediaButton: View {
         Button(action: action) {
             Image(systemName: icon)
                 .font(.system(size: size, weight: .medium))
-                .foregroundStyle(.white)
+                .foregroundStyle(Color(.label))
                 .frame(width: buttonSize, height: buttonSize)
                 .background(backgroundColor)
                 .clipShape(Circle())
                 .overlay(
                     Circle()
-                        .strokeBorder(Color.white.opacity(0.15), lineWidth: 1)
+                        .strokeBorder(Color(.separator), lineWidth: 1)
                 )
                 .scaleEffect(isPressed ? 0.9 : 1.0)
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
         .pressEvents {
             withAnimation(.spring(response: 0.2, dampingFraction: 0.6)) {
                 isPressed = true
@@ -180,7 +195,7 @@ struct MediaButton: View {
     }
 
     private var backgroundColor: Color {
-        isPrimary ? Color.white.opacity(0.2) : Color.white.opacity(0.1)
+        isPrimary ? Color(.tertiarySystemBackground) : Color(.secondarySystemBackground)
     }
 }
 
@@ -190,5 +205,4 @@ struct MediaButton: View {
             MediaFeature()
         }
     )
-    .preferredColorScheme(.dark)
 }

--- a/Projects/App/Sources/Features/Media/MediaView.swift
+++ b/Projects/App/Sources/Features/Media/MediaView.swift
@@ -44,13 +44,13 @@ public struct MediaView: View {
                 )
                 .accessibilityLabel("앨범 아트")
 
-            VStack(spacing: 4) {
+            VStack(spacing: 8) {
                 Text("Not Playing")
-                    .font(.system(size: 20, weight: .semibold))
+                    .font(.title3.weight(.semibold))
                     .foregroundStyle(Color(.label))
 
                 Text("Select a track to play")
-                    .font(.system(size: 14))
+                    .font(.subheadline)
                     .foregroundStyle(Color(.secondaryLabel))
             }
         }
@@ -100,7 +100,7 @@ public struct MediaView: View {
                     store.send(.volumeDownTapped)
                 } label: {
                     Image(systemName: "speaker.fill")
-                        .font(.system(size: 16))
+                        .font(.callout)
                         .foregroundStyle(Color(.secondaryLabel))
                 }
                 .accessibilityLabel("볼륨 줄이기")
@@ -119,7 +119,7 @@ public struct MediaView: View {
                     store.send(.volumeUpTapped)
                 } label: {
                     Image(systemName: "speaker.wave.3.fill")
-                        .font(.system(size: 16))
+                        .font(.callout)
                         .foregroundStyle(Color(.secondaryLabel))
                 }
                 .accessibilityLabel("볼륨 높이기")
@@ -132,14 +132,14 @@ public struct MediaView: View {
             } label: {
                 HStack(spacing: 8) {
                     Image(systemName: store.isMuted ? "speaker.slash.fill" : "speaker.wave.2.fill")
-                        .font(.system(size: 14))
+                        .font(.subheadline)
 
                     Text(store.isMuted ? "Unmute" : "Mute")
-                        .font(.system(size: 14, weight: .medium))
+                        .font(.subheadline.weight(.medium))
                 }
                 .foregroundStyle(store.isMuted ? .red : Color(.secondaryLabel))
-                .padding(.horizontal, 20)
-                .padding(.vertical, 10)
+                .padding(.horizontal, 24)
+                .padding(.vertical, 12)
                 .background(Color(.secondarySystemBackground))
                 .clipShape(Capsule())
                 .overlay(

--- a/Projects/App/Sources/Features/Trackpad/TrackpadView.swift
+++ b/Projects/App/Sources/Features/Trackpad/TrackpadView.swift
@@ -28,13 +28,7 @@ public struct TrackpadView: View {
             quickActions
                 .padding()
         }
-        .background(
-            LinearGradient(
-                colors: [Color(white: 0.08), Color.black],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-        )
+        .background(Color(.systemBackground))
     }
 
     // MARK: - Mode Toggle
@@ -53,10 +47,10 @@ public struct TrackpadView: View {
             }
         }
         .padding(4)
-        .background(Color(white: 0.12))
+        .background(Color(.secondarySystemBackground))
         .clipShape(toggleShape)
         .overlay(
-            toggleShape.strokeBorder(Color.white.opacity(0.05), lineWidth: 1)
+            toggleShape.strokeBorder(Color(.separator), lineWidth: 1)
         )
     }
 
@@ -114,7 +108,7 @@ public struct TrackpadView: View {
                 LaserClickButton(
                     icon: "cursorarrow.click",
                     label: "Right Click",
-                    color: .gray
+                    color: .secondary
                 ) {
                     store.send(.rightClickPressed)
                 } onRelease: {
@@ -166,7 +160,7 @@ struct ModeToggleButton: View {
                     .foregroundStyle(iconColor)
 
                 Text(mode.title)
-                    .font(.system(size: 14, weight: .bold))
+                    .font(.subheadline.weight(.bold))
                     .foregroundStyle(textColor)
             }
             .frame(maxWidth: .infinity)
@@ -181,6 +175,8 @@ struct ModeToggleButton: View {
             .shadow(color: shadowColor, radius: isSelected ? 8 : 0)
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("\(mode.title) 모드")
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
         .pressEvents {
             withAnimation(.easeInOut(duration: 0.1)) {
                 isPressed = true
@@ -196,21 +192,21 @@ struct ModeToggleButton: View {
         if mode == .laser && isSelected {
             return .red
         }
-        return isSelected ? .white : .gray
+        return isSelected ? Color(.label) : Color(.tertiaryLabel)
     }
 
     private var textColor: Color {
-        isSelected ? .white : .gray
+        isSelected ? Color(.label) : Color(.tertiaryLabel)
     }
 
-    private var background: AnyShapeStyle {
+    private var background: Color {
         if isSelected {
             if mode == .laser {
-                return AnyShapeStyle(Color.red.opacity(0.15))
+                return Color.red.opacity(0.15)
             }
-            return AnyShapeStyle(Color(white: 0.18))
+            return Color(.tertiarySystemBackground)
         }
-        return AnyShapeStyle(Color.clear)
+        return Color.clear
     }
 
     private var borderColor: Color {
@@ -218,7 +214,7 @@ struct ModeToggleButton: View {
             if mode == .laser {
                 return .red.opacity(0.3)
             }
-            return .white.opacity(0.1)
+            return Color(.separator)
         }
         return .clear
     }
@@ -242,15 +238,15 @@ struct TrackpadTouchArea: View {
             ZStack {
                 // Background
                 RoundedRectangle(cornerRadius: 24)
-                    .fill(Color(white: 0.06))
+                    .fill(Color(.secondarySystemBackground))
                     .overlay(
                         RoundedRectangle(cornerRadius: 24)
-                            .strokeBorder(Color.white.opacity(0.05), lineWidth: 1)
+                            .strokeBorder(Color(.separator), lineWidth: 1)
                     )
 
                 // Ping Animation (always animating in center)
                 Circle()
-                    .stroke(Color.white.opacity(0.1), lineWidth: 1)
+                    .stroke(Color(.tertiaryLabel), lineWidth: 1)
                     .frame(width: 120, height: 120)
                     .scaleEffect(pingAnimation ? 1.5 : 1.0)
                     .opacity(pingAnimation ? 0 : 0.3)
@@ -262,7 +258,7 @@ struct TrackpadTouchArea: View {
                 // Watermark
                 Text("TRACKPAD")
                     .font(.system(size: 32, weight: .black))
-                    .foregroundStyle(Color.white.opacity(0.04))
+                    .foregroundStyle(Color(.quaternaryLabel))
                     .tracking(10)
 
                 // Touch indicator - follows finger
@@ -270,7 +266,7 @@ struct TrackpadTouchArea: View {
                     Circle()
                         .fill(
                             RadialGradient(
-                                colors: [Color.white.opacity(0.25), Color.white.opacity(0)],
+                                colors: [Color.accentColor.opacity(0.3), Color.accentColor.opacity(0)],
                                 center: .center,
                                 startRadius: 0,
                                 endRadius: 60
@@ -309,6 +305,8 @@ struct TrackpadTouchArea: View {
             )
         }
         .padding(.horizontal)
+        .accessibilityLabel("트랙패드 터치 영역")
+        .accessibilityHint("드래그하여 마우스를 이동하고, 탭하여 클릭합니다")
         .onAppear {
             pingAnimation = true
         }
@@ -321,34 +319,20 @@ struct LaserControlArea: View {
     let store: StoreOf<TrackpadFeature>
     @State private var isHolding = false
 
-    private var laserButtonFill: AnyShapeStyle {
-        if isHolding {
-            return AnyShapeStyle(Color.red)
-        } else {
-            return AnyShapeStyle(
-                LinearGradient(
-                    colors: [Color(white: 0.15), Color(white: 0.08)],
-                    startPoint: .top,
-                    endPoint: .bottom
-                )
-            )
-        }
-    }
-
     var body: some View {
         ZStack {
             // Background
             RoundedRectangle(cornerRadius: 24)
-                .fill(Color(white: 0.04))
+                .fill(Color(.secondarySystemBackground))
                 .overlay(
                     RoundedRectangle(cornerRadius: 24)
-                        .strokeBorder(Color.white.opacity(0.05), lineWidth: 1)
+                        .strokeBorder(Color(.separator), lineWidth: 1)
                 )
 
             VStack(spacing: 8) {
                 Text("GYRO CONTROL")
-                    .font(.system(size: 10, weight: .bold))
-                    .foregroundStyle(Color.gray)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(Color(.secondaryLabel))
                     .tracking(2)
 
                 Spacer()
@@ -372,12 +356,12 @@ struct LaserControlArea: View {
 
                     // Main button
                     Circle()
-                        .fill(laserButtonFill)
+                        .fill(isHolding ? Color.red : Color(.tertiarySystemBackground))
                         .frame(width: 160, height: 160)
                         .overlay(
                             Circle()
                                 .strokeBorder(
-                                    isHolding ? Color.red.opacity(0.6) : Color.white.opacity(0.1),
+                                    isHolding ? Color.red.opacity(0.6) : Color(.separator),
                                     lineWidth: 2
                                 )
                         )
@@ -389,8 +373,8 @@ struct LaserControlArea: View {
                             .foregroundStyle(isHolding ? .white : .red)
 
                         Text(isHolding ? "GYRO ACTIVE" : "HOLD TO MOVE")
-                            .font(.system(size: 11, weight: .bold))
-                            .foregroundStyle(isHolding ? .white : .gray)
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(isHolding ? .white : Color(.secondaryLabel))
                             .tracking(1)
                     }
                 }
@@ -406,6 +390,8 @@ struct LaserControlArea: View {
                             isHolding = false
                         }
                 )
+                .accessibilityLabel("레이저 포인터 버튼")
+                .accessibilityHint("길게 눌러 자이로스코프로 마우스를 제어합니다")
 
                 Spacer()
             }
@@ -446,15 +432,15 @@ struct ClickButton: View {
 
     var body: some View {
         Text(label)
-            .font(.system(size: 16, weight: .bold))
-            .foregroundStyle(isPrimary ? .white : Color.white.opacity(0.5))
+            .font(.headline)
+            .foregroundStyle(isPrimary ? Color(.label) : Color(.secondaryLabel))
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(
                 RoundedRectangle(cornerRadius: 16)
-                    .fill(isPressed ? Color.white.opacity(0.15) : Color.white.opacity(0.05))
+                    .fill(isPressed ? Color(.tertiarySystemFill) : Color(.secondarySystemBackground))
                     .overlay(
                         RoundedRectangle(cornerRadius: 16)
-                            .strokeBorder(Color.white.opacity(0.08), lineWidth: 1)
+                            .strokeBorder(Color(.separator), lineWidth: 1)
                     )
             )
             .scaleEffect(isPressed ? 0.95 : 1.0)
@@ -472,6 +458,7 @@ struct ClickButton: View {
                         onRelease()
                     }
             )
+            .accessibilityLabel(isPrimary ? "왼쪽 클릭" : "오른쪽 클릭")
     }
 }
 
@@ -489,20 +476,20 @@ struct LaserClickButton: View {
     var body: some View {
         VStack(spacing: 6) {
             Image(systemName: icon)
-                .font(.system(size: 24, weight: .medium))
-                .foregroundStyle(isPressed ? .white : color)
+                .font(.title2)
+                .foregroundStyle(isPressed ? Color(.label) : color)
 
             Text(label)
-                .font(.system(size: 10, weight: .bold))
-                .foregroundStyle(Color.white.opacity(0.7))
+                .font(.caption.weight(.bold))
+                .foregroundStyle(Color(.secondaryLabel))
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(
             RoundedRectangle(cornerRadius: 16)
-                .fill(isPressed ? Color.white.opacity(0.15) : Color(white: 0.08))
+                .fill(isPressed ? Color(.tertiarySystemFill) : Color(.secondarySystemBackground))
                 .overlay(
                     RoundedRectangle(cornerRadius: 16)
-                        .strokeBorder(Color.white.opacity(0.05), lineWidth: 1)
+                        .strokeBorder(Color(.separator), lineWidth: 1)
                 )
         )
         .scaleEffect(isPressed ? 0.95 : 1.0)
@@ -520,6 +507,7 @@ struct LaserClickButton: View {
                     onRelease()
                 }
         )
+        .accessibilityLabel(label)
     }
 }
 
@@ -536,25 +524,26 @@ struct QuickActionButton: View {
         Button(action: action) {
             VStack(spacing: 8) {
                 Image(systemName: icon)
-                    .font(.system(size: 24, weight: .medium))
-                    .foregroundStyle(Color.white.opacity(0.7))
+                    .font(.title2)
+                    .foregroundStyle(Color(.secondaryLabel))
 
                 Text(label)
-                    .font(.system(size: 10, weight: .bold))
-                    .foregroundStyle(Color.gray)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(Color(.tertiaryLabel))
                     .textCase(.uppercase)
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 16)
-            .background(Color(white: 0.1))
+            .background(Color(.secondarySystemBackground))
             .clipShape(RoundedRectangle(cornerRadius: 16))
             .overlay(
                 RoundedRectangle(cornerRadius: 16)
-                    .strokeBorder(Color.white.opacity(0.05), lineWidth: 1)
+                    .strokeBorder(Color(.separator), lineWidth: 1)
             )
             .scaleEffect(isPressed ? 0.95 : 1.0)
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(label)
         .pressEvents {
             withAnimation(.spring(response: 0.15, dampingFraction: 0.6)) {
                 isPressed = true
@@ -595,5 +584,4 @@ extension View {
             TrackpadFeature()
         }
     )
-    .preferredColorScheme(.dark)
 }

--- a/Projects/App/Sources/Features/Trackpad/TrackpadView.swift
+++ b/Projects/App/Sources/Features/Trackpad/TrackpadView.swift
@@ -34,9 +34,9 @@ public struct TrackpadView: View {
     // MARK: - Mode Toggle
 
     private var modeToggle: some View {
-        let toggleShape = RoundedRectangle(cornerRadius: 14)
+        let toggleShape = RoundedRectangle(cornerRadius: 12)
 
-        return HStack(spacing: 4) {
+        return HStack(spacing: 8) {
             ForEach(TrackpadFeature.InputMode.allCases, id: \.self) { mode in
                 ModeToggleButton(
                     mode: mode,
@@ -46,7 +46,7 @@ public struct TrackpadView: View {
                 }
             }
         }
-        .padding(4)
+        .padding(8)
         .background(Color(.secondarySystemBackground))
         .clipShape(toggleShape)
         .overlay(
@@ -64,7 +64,7 @@ public struct TrackpadView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             // Click Buttons - Inside the touch area at bottom
-            HStack(spacing: 12) {
+            HStack(spacing: 16) {
                 ClickButton(label: "L", isPrimary: true) {
                     store.send(.leftClickPressed)
                 } onRelease: {
@@ -79,6 +79,7 @@ public struct TrackpadView: View {
             }
             .frame(height: 64)
             .padding(.horizontal)
+            .padding(.top, 16)
             .padding(.bottom, 8)
         }
         .transition(.opacity.combined(with: .scale(scale: 0.98)))
@@ -94,7 +95,7 @@ public struct TrackpadView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             // Click Buttons
-            HStack(spacing: 12) {
+            HStack(spacing: 16) {
                 LaserClickButton(
                     icon: "cursorarrow.click",
                     label: "Left Click",
@@ -125,7 +126,7 @@ public struct TrackpadView: View {
 
     @ViewBuilder
     private var quickActions: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: 16) {
             QuickActionButton(
                 icon: "command",
                 label: "Cmd+Space"
@@ -156,7 +157,7 @@ struct ModeToggleButton: View {
         Button(action: action) {
             HStack(spacing: 8) {
                 Image(systemName: mode == .trackpad ? "hand.point.up.left" : "scope")
-                    .font(.system(size: 14, weight: .semibold))
+                    .font(.subheadline.weight(.semibold))
                     .foregroundStyle(iconColor)
 
                 Text(mode.title)
@@ -166,9 +167,9 @@ struct ModeToggleButton: View {
             .frame(maxWidth: .infinity)
             .padding(.vertical, 12)
             .background(background)
-            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
             .overlay(
-                RoundedRectangle(cornerRadius: 10)
+                RoundedRectangle(cornerRadius: 8)
                     .strokeBorder(borderColor, lineWidth: 1)
             )
             .scaleEffect(isPressed ? 0.95 : 1.0)
@@ -257,7 +258,7 @@ struct TrackpadTouchArea: View {
 
                 // Watermark
                 Text("TRACKPAD")
-                    .font(.system(size: 32, weight: .black))
+                    .font(.largeTitle.weight(.black))
                     .foregroundStyle(Color(.quaternaryLabel))
                     .tracking(10)
 
@@ -474,13 +475,13 @@ struct LaserClickButton: View {
     @State private var isPressed = false
 
     var body: some View {
-        VStack(spacing: 6) {
+        VStack(spacing: 8) {
             Image(systemName: icon)
                 .font(.title2)
                 .foregroundStyle(isPressed ? Color(.label) : color)
 
             Text(label)
-                .font(.caption.weight(.bold))
+                .font(.caption.weight(.semibold))
                 .foregroundStyle(Color(.secondaryLabel))
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -528,7 +529,7 @@ struct QuickActionButton: View {
                     .foregroundStyle(Color(.secondaryLabel))
 
                 Text(label)
-                    .font(.caption.weight(.bold))
+                    .font(.caption.weight(.semibold))
                     .foregroundStyle(Color(.tertiaryLabel))
                     .textCase(.uppercase)
             }


### PR DESCRIPTION
## Summary

- TrackpadView, KeyboardView, MediaView를 Apple Human Interface Guidelines에 맞게 수정
- 하드코딩된 다크 테마 색상을 시스템 시맨틱 색상으로 변환하여 라이트/다크 모드 자동 대응
- 모든 인터랙티브 요소에 접근성 레이블 추가

### 변경 전후 비교

| Before | After |
|--------|-------|
| `Color.black` | `Color(.systemBackground)` |
| `Color.white.opacity(0.1)` | `Color(.secondarySystemBackground)` |
| `Color.white` | `Color(.label)` |
| `.gray` | `Color(.secondaryLabel)` |

### 접근성 개선
- 트랙패드: 터치 영역, 클릭 버튼에 접근성 레이블 추가
- 키보드: 모든 키에 접근성 레이블 및 힌트 추가
- 미디어: 재생 컨트롤, 볼륨 슬라이더에 접근성 레이블 추가

## Test plan
- [ ] 라이트 모드에서 UI 확인
- [ ] 다크 모드에서 UI 확인
- [ ] VoiceOver로 접근성 레이블 확인
- [ ] 모든 인터랙션 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)