### PR TITLE
[Feat]: 앱 컨트롤러 구현 - NSWorkspace 기반 앱 관리

### DIFF
--- a/Projects/App/Sources/Features/App/AppFeature.swift
+++ b/Projects/App/Sources/Features/App/AppFeature.swift
@@ -123,6 +123,9 @@ public struct AppFeature {
                 state.isSettingsPresented = false
                 return .none
 
+            case .connection(.appListReceived(let apps)):
+                return .send(.productivity(.appListReceived(apps)))
+
             case .connection:
                 return .none
 

--- a/Projects/App/Sources/Features/Productivity/ProductivityFeature.swift
+++ b/Projects/App/Sources/Features/Productivity/ProductivityFeature.swift
@@ -6,6 +6,8 @@ public struct ProductivityFeature {
     @ObservableState
     public struct State: Equatable {
         public var isSiriActive: Bool = false
+        public var runningApps: [AppInfo] = []
+        public var isLoadingApps: Bool = false
     }
 
     public enum Action: Equatable, Sendable {
@@ -17,6 +19,11 @@ public struct ProductivityFeature {
 
         // Window Snap
         case windowSnapTapped(WindowSnap.Position)
+
+        // App Switcher
+        case requestAppListTapped
+        case appListReceived([AppInfo])
+        case appTapped(AppInfo)
     }
 
     @Dependency(\.connectionClient) var connectionClient
@@ -58,6 +65,22 @@ public struct ProductivityFeature {
             case .windowSnapTapped(let position):
                 return .run { _ in
                     await client.sendWindowSnap(position)
+                }
+
+            case .requestAppListTapped:
+                state.isLoadingApps = true
+                return .run { _ in
+                    await client.requestAppList()
+                }
+
+            case .appListReceived(let apps):
+                state.isLoadingApps = false
+                state.runningApps = apps
+                return .none
+
+            case .appTapped(let app):
+                return .run { _ in
+                    await client.sendAppFocus(app.bundleID, app.pid)
                 }
             }
         }

--- a/Projects/App/Sources/Features/Productivity/ProductivityView.swift
+++ b/Projects/App/Sources/Features/Productivity/ProductivityView.swift
@@ -117,36 +117,117 @@ public struct ProductivityView: View {
     @ViewBuilder
     private var appSwitcherSection: some View {
         VStack(spacing: 16) {
-            Text("앱 스위처")
-                .font(.headline)
-                .frame(maxWidth: .infinity, alignment: .leading)
-
             HStack {
-                Image(systemName: "square.stack.3d.up")
-                    .font(.system(size: 40))
-                    .foregroundStyle(.purple)
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("앱 목록 불러오기")
-                        .font(.subheadline)
-                        .fontWeight(.medium)
-                    Text("Mac에서 실행 중인 앱 목록")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
+                Text("앱 스위처")
+                    .font(.headline)
 
                 Spacer()
 
-                Button("불러오기") {
-                    // TODO: Request app list
+                Button {
+                    store.send(.requestAppListTapped)
+                } label: {
+                    if store.isLoadingApps {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Image(systemName: "arrow.clockwise")
+                    }
                 }
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.bordered)
                 .controlSize(.small)
+                .disabled(store.isLoadingApps)
+            }
+
+            if store.runningApps.isEmpty {
+                // Empty state
+                HStack {
+                    Image(systemName: "square.stack.3d.up")
+                        .font(.system(size: 40))
+                        .foregroundStyle(.purple)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("앱 목록 불러오기")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        Text("Mac에서 실행 중인 앱 목록")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer()
+
+                    Button("불러오기") {
+                        store.send(.requestAppListTapped)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .disabled(store.isLoadingApps)
+                }
+            } else {
+                // App grid
+                LazyVGrid(columns: [
+                    GridItem(.flexible()),
+                    GridItem(.flexible()),
+                    GridItem(.flexible()),
+                    GridItem(.flexible())
+                ], spacing: 16) {
+                    ForEach(store.runningApps, id: \.bundleID) { app in
+                        AppButton(app: app, isActive: app.isActive) {
+                            store.send(.appTapped(app))
+                        }
+                    }
+                }
             }
         }
         .padding()
         .background(Color(.secondarySystemBackground).opacity(0.5))
         .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+}
+
+// MARK: - App Button
+
+struct AppButton: View {
+    let app: AppInfo
+    let isActive: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 8) {
+                // App icon
+                if let uiImage = UIImage(data: app.iconData) {
+                    Image(uiImage: uiImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 48, height: 48)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                } else {
+                    Image(systemName: "app.fill")
+                        .font(.system(size: 32))
+                        .foregroundStyle(.purple)
+                        .frame(width: 48, height: 48)
+                }
+
+                // App name
+                Text(app.name)
+                    .font(.caption2)
+                    .lineLimit(1)
+                    .foregroundStyle(isActive ? .primary : .secondary)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(isActive ? Color.purple.opacity(0.15) : Color(.tertiarySystemBackground))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(isActive ? Color.purple.opacity(0.3) : Color.clear, lineWidth: 2)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(app.name) 앱\(isActive ? ", 활성화됨" : "")")
     }
 }
 

--- a/Projects/MacReceiver/Sources/MacReceiverApp.swift
+++ b/Projects/MacReceiver/Sources/MacReceiverApp.swift
@@ -424,12 +424,14 @@ final class ServerManager: ObservableObject {
             logPacket("WindowSnap: \(snap.position)")
 
         case .appListRequest:
-            // TODO: Send app list response
-            logPacket("AppListRequest")
+            let apps = AppController.shared.getRunningApps()
+            let response = AppListResponse(apps: apps)
+            server?.sendAppListResponse(response)
+            logPacket("AppListRequest: sent \(apps.count) apps")
 
         case .appFocus(let focus, _):
-            // TODO: Focus app
-            logPacket("AppFocus: \(focus.bundleID)")
+            let success = AppController.shared.focusApp(bundleID: focus.bundleID, pid: focus.pid)
+            logPacket("AppFocus: \(focus.bundleID) - \(success ? "success" : "failed")")
 
         case .presentation(let pres, _):
             // TODO: Presentation control

--- a/Projects/MacReceiver/Sources/Server/AppController.swift
+++ b/Projects/MacReceiver/Sources/Server/AppController.swift
@@ -1,0 +1,152 @@
+import AppKit
+import Foundation
+import Shared
+
+/// 앱 컨트롤러
+/// NSWorkspace를 사용하여 앱 관리 및 스위칭 기능을 제공합니다.
+@MainActor
+public final class AppController {
+    public static let shared = AppController()
+
+    private let workspace = NSWorkspace.shared
+    private let iconSize: CGFloat = 64
+
+    private init() {}
+
+    // MARK: - Public Methods
+
+    /// 실행 중인 앱 목록 조회
+    public func getRunningApps() -> [AppInfo] {
+        let runningApps = workspace.runningApplications
+
+        return runningApps.compactMap { app -> AppInfo? in
+            // 일반 앱만 포함 (백그라운드 앱 제외)
+            guard app.activationPolicy == .regular else { return nil }
+            guard let bundleID = app.bundleIdentifier else { return nil }
+            guard let name = app.localizedName else { return nil }
+
+            let iconData = extractIconData(for: app)
+
+            return AppInfo(
+                bundleID: bundleID,
+                name: name,
+                iconData: iconData,
+                isActive: app.isActive,
+                pid: UInt32(app.processIdentifier)
+            )
+        }
+    }
+
+    /// 앱 포커스 전환
+    public func focusApp(bundleID: String, pid: UInt32) -> Bool {
+        // PID로 먼저 시도
+        if pid > 0 {
+            let runningApps = workspace.runningApplications
+            if let app = runningApps.first(where: { $0.processIdentifier == pid_t(pid) }) {
+                return app.activate()
+            }
+        }
+
+        // BundleID로 시도
+        let runningApps = workspace.runningApplications
+        if let app = runningApps.first(where: { $0.bundleIdentifier == bundleID }) {
+            return app.activate()
+        }
+
+        return false
+    }
+
+    /// 앱 실행
+    public func launchApp(bundleID: String) -> Bool {
+        guard let appURL = workspace.urlForApplication(withBundleIdentifier: bundleID) else {
+            return false
+        }
+
+        workspace.open(appURL)
+        return true
+    }
+
+    /// 앱 종료
+    public func terminateApp(bundleID: String, pid: UInt32) -> Bool {
+        let runningApps = workspace.runningApplications
+
+        // PID로 먼저 시도
+        if pid > 0 {
+            if let app = runningApps.first(where: { $0.processIdentifier == pid_t(pid) }) {
+                return app.terminate()
+            }
+        }
+
+        // BundleID로 시도
+        if let app = runningApps.first(where: { $0.bundleIdentifier == bundleID }) {
+            return app.terminate()
+        }
+
+        return false
+    }
+
+    /// 앱 강제 종료
+    public func forceTerminateApp(bundleID: String, pid: UInt32) -> Bool {
+        let runningApps = workspace.runningApplications
+
+        // PID로 먼저 시도
+        if pid > 0 {
+            if let app = runningApps.first(where: { $0.processIdentifier == pid_t(pid) }) {
+                return app.forceTerminate()
+            }
+        }
+
+        // BundleID로 시도
+        if let app = runningApps.first(where: { $0.bundleIdentifier == bundleID }) {
+            return app.forceTerminate()
+        }
+
+        return false
+    }
+
+    /// 현재 활성 앱 정보
+    public func getActiveApp() -> AppInfo? {
+        guard let frontApp = workspace.frontmostApplication else { return nil }
+        guard let bundleID = frontApp.bundleIdentifier else { return nil }
+        guard let name = frontApp.localizedName else { return nil }
+
+        let iconData = extractIconData(for: frontApp)
+
+        return AppInfo(
+            bundleID: bundleID,
+            name: name,
+            iconData: iconData,
+            isActive: true,
+            pid: UInt32(frontApp.processIdentifier)
+        )
+    }
+
+    // MARK: - Private Methods
+
+    /// 앱 아이콘 추출 (64x64 PNG)
+    private func extractIconData(for app: NSRunningApplication) -> Data {
+        guard let icon = app.icon else { return Data() }
+
+        // 64x64 크기로 리사이즈
+        let targetSize = NSSize(width: iconSize, height: iconSize)
+        let resizedImage = NSImage(size: targetSize)
+
+        resizedImage.lockFocus()
+        icon.draw(
+            in: NSRect(origin: .zero, size: targetSize),
+            from: NSRect(origin: .zero, size: icon.size),
+            operation: .copy,
+            fraction: 1.0
+        )
+        resizedImage.unlockFocus()
+
+        // PNG로 변환
+        guard let tiffData = resizedImage.tiffRepresentation,
+              let bitmapRep = NSBitmapImageRep(data: tiffData),
+              let pngData = bitmapRep.representation(using: .png, properties: [:]) else {
+            return Data()
+        }
+
+        return pngData
+    }
+}

--- a/Projects/MacReceiver/Sources/Server/SnapServer.swift
+++ b/Projects/MacReceiver/Sources/Server/SnapServer.swift
@@ -112,6 +112,12 @@ public final class SnapServer: @unchecked Sendable {
         }
     }
 
+    /// 앱 목록 응답 전송
+    public func sendAppListResponse(_ response: AppListResponse) {
+        guard let client = connectedClient else { return }
+        client.send(response, type: .appListResponse)
+    }
+
     // MARK: - Private Methods
 
     private static func getDeviceID() -> String {


### PR DESCRIPTION
## Summary
- MacReceiver에 AppController 추가 (NSWorkspace 기반 앱 관리)
- 실행 중인 앱 목록 조회 및 아이콘 추출 (64x64 PNG)
- 앱 포커스 전환 기능
- iOS 앱 스위처 UI 구현 (그리드 레이아웃)

## Changes
### MacReceiver
- `AppController.swift`: 앱 목록 조회, 포커스 전환, 실행/종료
- `SnapServer.swift`: `sendAppListResponse` 메서드 추가
- `MacReceiverApp.swift`: appListRequest, appFocus 패킷 처리

### iOS App
- `ProductivityFeature`: runningApps 상태, 앱 스위처 액션 추가
- `ProductivityView`: 앱 스위처 UI (AppButton 컴포넌트)
- `AppFeature`: ConnectionFeature → ProductivityFeature 앱 목록 전달

## Test plan
- [ ] MacReceiver 실행 후 iOS 앱에서 "불러오기" 탭
- [ ] 앱 목록이 그리드로 표시되는지 확인
- [ ] 앱 아이콘과 이름이 올바르게 표시되는지 확인
- [ ] 앱 탭 시 해당 앱으로 포커스 전환되는지 확인
- [ ] 활성 앱이 보라색 테두리로 표시되는지 확인

Close #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)