### PR TITLE
[Feat]: 매크로 패드 구현 - Bento Grid UI

### DIFF
--- a/Projects/App/Sources/Features/Macro/MacroFeature.swift
+++ b/Projects/App/Sources/Features/Macro/MacroFeature.swift
@@ -1,0 +1,82 @@
+import ComposableArchitecture
+import Foundation
+import Shared
+
+@Reducer
+public struct MacroFeature {
+    @ObservableState
+    public struct State: Equatable {
+        public var macros: [Macro] = Macro.defaults
+        public var isEditing: Bool = false
+        public var selectedMacro: Macro?
+
+        public init() {}
+    }
+
+    public enum Action: Equatable, Sendable {
+        case macroTapped(Macro)
+        case macroLongPressed(Macro)
+        case editModeToggled
+        case macroDeleted(Macro)
+        case macroMoved(from: IndexSet, to: Int)
+        case dismissEditor
+        case saveMacro(Macro)
+    }
+
+    @Dependency(\.connectionClient) var connectionClient
+
+    public init() {}
+
+    public var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            let client = connectionClient
+
+            switch action {
+            case .macroTapped(let macro):
+                guard !state.isEditing else {
+                    state.selectedMacro = macro
+                    return .none
+                }
+
+                return .run { _ in
+                    await client.sendKeyCombo(
+                        macro.keyCombo.keyCodes,
+                        macro.keyCombo.modifiers
+                    )
+                }
+
+            case .macroLongPressed(let macro):
+                state.selectedMacro = macro
+                return .none
+
+            case .editModeToggled:
+                state.isEditing.toggle()
+                if !state.isEditing {
+                    state.selectedMacro = nil
+                }
+                return .none
+
+            case .macroDeleted(let macro):
+                state.macros.removeAll { $0.id == macro.id }
+                return .none
+
+            case .macroMoved(let from, let to):
+                state.macros.move(fromOffsets: from, toOffset: to)
+                return .none
+
+            case .dismissEditor:
+                state.selectedMacro = nil
+                return .none
+
+            case .saveMacro(let macro):
+                if let index = state.macros.firstIndex(where: { $0.id == macro.id }) {
+                    state.macros[index] = macro
+                } else {
+                    state.macros.append(macro)
+                }
+                state.selectedMacro = nil
+                return .none
+            }
+        }
+    }
+}

--- a/Projects/App/Sources/Features/Macro/MacroView.swift
+++ b/Projects/App/Sources/Features/Macro/MacroView.swift
@@ -1,0 +1,289 @@
+import ComposableArchitecture
+import Shared
+import SwiftUI
+
+public struct MacroView: View {
+    @Bindable var store: StoreOf<MacroFeature>
+
+    private let columns = [
+        GridItem(.flexible(), spacing: 12),
+        GridItem(.flexible(), spacing: 12),
+        GridItem(.flexible(), spacing: 12),
+        GridItem(.flexible(), spacing: 12),
+    ]
+
+    public init(store: StoreOf<MacroFeature>) {
+        self.store = store
+    }
+
+    public var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                // Header
+                header
+                    .padding(.horizontal)
+
+                // Bento Grid
+                bentoGrid
+                    .padding(.horizontal)
+            }
+            .padding(.vertical)
+        }
+        .background(Color(.systemBackground))
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            Text("매크로 패드")
+                .font(.title2.weight(.bold))
+
+            Spacer()
+
+            Button {
+                store.send(.editModeToggled)
+            } label: {
+                Text(store.isEditing ? "완료" : "편집")
+                    .font(.subheadline.weight(.medium))
+            }
+        }
+    }
+
+    // MARK: - Bento Grid
+
+    private var bentoGrid: some View {
+        LazyVGrid(columns: columns, spacing: 12) {
+            ForEach(store.macros) { macro in
+                MacroButton(
+                    macro: macro,
+                    isEditing: store.isEditing
+                ) {
+                    store.send(.macroTapped(macro))
+                } onLongPress: {
+                    store.send(.macroLongPressed(macro))
+                } onDelete: {
+                    store.send(.macroDeleted(macro))
+                }
+                .gridCellColumns(macro.size.columnSpan)
+            }
+        }
+    }
+}
+
+// MARK: - Macro Button
+
+struct MacroButton: View {
+    let macro: Macro
+    let isEditing: Bool
+    let onTap: () -> Void
+    let onLongPress: () -> Void
+    let onDelete: () -> Void
+
+    @State private var isPressed = false
+    @State private var isWiggling = false
+
+    var body: some View {
+        Button {
+            onTap()
+        } label: {
+            content
+        }
+        .buttonStyle(.plain)
+        .scaleEffect(isPressed ? 0.95 : 1.0)
+        .rotationEffect(.degrees(isEditing && isWiggling ? 1.5 : 0))
+        .animation(
+            isEditing
+                ? .easeInOut(duration: 0.1).repeatForever(autoreverses: true)
+                : .default,
+            value: isWiggling
+        )
+        .simultaneousGesture(
+            LongPressGesture(minimumDuration: 0.5)
+                .onEnded { _ in
+                    onLongPress()
+                }
+        )
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { _ in
+                    if !isPressed {
+                        withAnimation(.spring(response: 0.2)) {
+                            isPressed = true
+                        }
+                    }
+                }
+                .onEnded { _ in
+                    withAnimation(.spring(response: 0.2)) {
+                        isPressed = false
+                    }
+                }
+        )
+        .overlay(alignment: .topTrailing) {
+            if isEditing {
+                deleteButton
+            }
+        }
+        .onChange(of: isEditing) { _, editing in
+            isWiggling = editing
+        }
+        .accessibilityLabel("\(macro.name) 매크로")
+    }
+
+    private var content: some View {
+        VStack(spacing: 8) {
+            Image(systemName: macro.icon)
+                .font(.system(size: macro.size == .large ? 32 : 24))
+                .foregroundStyle(.white)
+
+            Text(macro.name)
+                .font(macro.size == .small ? .caption2 : .caption)
+                .fontWeight(.medium)
+                .foregroundStyle(.white.opacity(0.9))
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: macro.size.height)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(macro.color.gradient)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .strokeBorder(.white.opacity(0.2), lineWidth: 1)
+        )
+        .shadow(color: macro.color.color.opacity(0.3), radius: 8, y: 4)
+    }
+
+    private var deleteButton: some View {
+        Button {
+            onDelete()
+        } label: {
+            Image(systemName: "xmark.circle.fill")
+                .font(.title3)
+                .foregroundStyle(.white, .red)
+        }
+        .offset(x: 8, y: -8)
+    }
+}
+
+// MARK: - Macro Size Extension
+
+extension MacroSize {
+    var columnSpan: Int {
+        switch self {
+        case .small: return 1
+        case .medium: return 2
+        case .large: return 2
+        }
+    }
+
+    var height: CGFloat {
+        switch self {
+        case .small: return 80
+        case .medium: return 80
+        case .large: return 172
+        }
+    }
+}
+
+// MARK: - Macro Color Extension
+
+extension MacroColor {
+    var color: Color {
+        switch self {
+        case .blue: return .blue
+        case .purple: return .purple
+        case .pink: return .pink
+        case .red: return .red
+        case .orange: return .orange
+        case .yellow: return .yellow
+        case .green: return .green
+        case .teal: return .teal
+        case .gray: return .gray
+        }
+    }
+
+    var gradient: LinearGradient {
+        LinearGradient(
+            colors: [color, color.opacity(0.8)],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+}
+
+// MARK: - Macro Pad Section (for embedding in ProductivityView)
+
+public struct MacroPadSection: View {
+    @Bindable var store: StoreOf<MacroFeature>
+
+    private let columns = [
+        GridItem(.flexible(), spacing: 12),
+        GridItem(.flexible(), spacing: 12),
+        GridItem(.flexible(), spacing: 12),
+        GridItem(.flexible(), spacing: 12),
+    ]
+
+    public init(store: StoreOf<MacroFeature>) {
+        self.store = store
+    }
+
+    public var body: some View {
+        VStack(spacing: 16) {
+            // Header
+            HStack {
+                Text("매크로 패드")
+                    .font(.headline)
+
+                Spacer()
+
+                Button {
+                    store.send(.editModeToggled)
+                } label: {
+                    Text(store.isEditing ? "완료" : "편집")
+                        .font(.caption)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+
+            // Bento Grid
+            LazyVGrid(columns: columns, spacing: 12) {
+                ForEach(store.macros) { macro in
+                    MacroButton(
+                        macro: macro,
+                        isEditing: store.isEditing
+                    ) {
+                        store.send(.macroTapped(macro))
+                    } onLongPress: {
+                        store.send(.macroLongPressed(macro))
+                    } onDelete: {
+                        store.send(.macroDeleted(macro))
+                    }
+                    .gridCellColumns(macro.size.columnSpan)
+                }
+            }
+        }
+        .padding()
+        .background(Color(.secondarySystemBackground).opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+}
+
+#Preview {
+    MacroView(
+        store: Store(initialState: MacroFeature.State()) {
+            MacroFeature()
+        }
+    )
+}
+
+#Preview("MacroPadSection") {
+    MacroPadSection(
+        store: Store(initialState: MacroFeature.State()) {
+            MacroFeature()
+        }
+    )
+    .padding()
+}

--- a/Projects/App/Sources/Features/Productivity/ProductivityFeature.swift
+++ b/Projects/App/Sources/Features/Productivity/ProductivityFeature.swift
@@ -8,6 +8,7 @@ public struct ProductivityFeature {
         public var isSiriActive: Bool = false
         public var runningApps: [AppInfo] = []
         public var isLoadingApps: Bool = false
+        public var macro: MacroFeature.State = .init()
     }
 
     public enum Action: Equatable, Sendable {
@@ -24,6 +25,9 @@ public struct ProductivityFeature {
         case requestAppListTapped
         case appListReceived([AppInfo])
         case appTapped(AppInfo)
+
+        // Macro
+        case macro(MacroFeature.Action)
     }
 
     @Dependency(\.connectionClient) var connectionClient
@@ -31,6 +35,10 @@ public struct ProductivityFeature {
     public init() {}
 
     public var body: some ReducerOf<Self> {
+        Scope(state: \.macro, action: \.macro) {
+            MacroFeature()
+        }
+
         Reduce { state, action in
             let client = connectionClient
 
@@ -82,6 +90,9 @@ public struct ProductivityFeature {
                 return .run { _ in
                     await client.sendAppFocus(app.bundleID, app.pid)
                 }
+
+            case .macro:
+                return .none
             }
         }
     }

--- a/Projects/App/Sources/Features/Productivity/ProductivityView.swift
+++ b/Projects/App/Sources/Features/Productivity/ProductivityView.swift
@@ -12,19 +12,31 @@ public struct ProductivityView: View {
     public var body: some View {
         ScrollView {
             VStack(spacing: 24) {
+                // Macro Pad Section
+                macroSection
+
                 // Siri Section
                 siriSection
 
-                // Window Snap Section (Placeholder)
+                // Window Snap Section
                 windowSnapSection
 
-                // App Switcher Section (Placeholder)
+                // App Switcher Section
                 appSwitcherSection
             }
             .padding()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color(.systemBackground))
+    }
+
+    // MARK: - Macro Section
+
+    @ViewBuilder
+    private var macroSection: some View {
+        MacroPadSection(
+            store: store.scope(state: \.macro, action: \.macro)
+        )
     }
 
     // MARK: - Siri Section

--- a/Projects/Shared/Sources/Protocol/MacroMessages.swift
+++ b/Projects/Shared/Sources/Protocol/MacroMessages.swift
@@ -1,0 +1,228 @@
+import Foundation
+
+// MARK: - Macro
+
+/// 매크로 정의
+public struct Macro: Codable, Sendable, Equatable, Identifiable {
+    public var id: UUID
+    public var name: String
+    public var icon: String
+    public var color: MacroColor
+    public var size: MacroSize
+    public var keyCombo: KeyCombo
+
+    public init(
+        id: UUID = UUID(),
+        name: String,
+        icon: String,
+        color: MacroColor = .blue,
+        size: MacroSize = .small,
+        keyCombo: KeyCombo
+    ) {
+        self.id = id
+        self.name = name
+        self.icon = icon
+        self.color = color
+        self.size = size
+        self.keyCombo = keyCombo
+    }
+}
+
+// MARK: - Macro Color
+
+/// 매크로 색상
+public enum MacroColor: String, Codable, Sendable, CaseIterable {
+    case blue
+    case purple
+    case pink
+    case red
+    case orange
+    case yellow
+    case green
+    case teal
+    case gray
+}
+
+// MARK: - Macro Size
+
+/// Bento Grid 크기
+public enum MacroSize: String, Codable, Sendable, CaseIterable {
+    case small      // 1x1
+    case medium     // 2x1
+    case large      // 2x2
+}
+
+// MARK: - Default Macros
+
+public extension Macro {
+    /// 기본 제공 매크로
+    static let defaults: [Macro] = [
+        // 편집
+        Macro(
+            name: "복사",
+            icon: "doc.on.doc",
+            color: .blue,
+            size: .small,
+            keyCombo: KeyCombo(
+                keyCodes: [KeyCode.c],
+                modifiers: ModifierFlags.command.rawValue
+            )
+        ),
+        Macro(
+            name: "붙여넣기",
+            icon: "doc.on.clipboard",
+            color: .blue,
+            size: .small,
+            keyCombo: KeyCombo(
+                keyCodes: [KeyCode.v],
+                modifiers: ModifierFlags.command.rawValue
+            )
+        ),
+        Macro(
+            name: "잘라내기",
+            icon: "scissors",
+            color: .blue,
+            size: .small,
+            keyCombo: KeyCombo(
+                keyCodes: [KeyCode.x],
+                modifiers: ModifierFlags.command.rawValue
+            )
+        ),
+        Macro(
+            name: "실행취소",
+            icon: "arrow.uturn.backward",
+            color: .orange,
+            size: .small,
+            keyCombo: KeyCombo(
+                keyCodes: [KeyCode.z],
+                modifiers: ModifierFlags.command.rawValue
+            )
+        ),
+        Macro(
+            name: "다시실행",
+            icon: "arrow.uturn.forward",
+            color: .orange,
+            size: .small,
+            keyCombo: KeyCombo(
+                keyCodes: [KeyCode.z],
+                modifiers: ModifierFlags.command.rawValue | ModifierFlags.shift.rawValue
+            )
+        ),
+        Macro(
+            name: "전체선택",
+            icon: "selection.pin.in.out",
+            color: .purple,
+            size: .small,
+            keyCombo: KeyCombo(
+                keyCodes: [KeyCode.a],
+                modifiers: ModifierFlags.command.rawValue
+            )
+        ),
+
+        // 시스템
+        Macro(
+            name: "스크린샷",
+            icon: "camera.viewfinder",
+            color: .green,
+            size: .medium,
+            keyCombo: KeyCombo(
+                keyCodes: [KeyCode.num4],
+                modifiers: ModifierFlags.command.rawValue | ModifierFlags.shift.rawValue
+            )
+        ),
+        Macro(
+            name: "저장",
+            icon: "square.and.arrow.down",
+            color: .teal,
+            size: .small,
+            keyCombo: KeyCombo(
+                keyCodes: [KeyCode.s],
+                modifiers: ModifierFlags.command.rawValue
+            )
+        ),
+        Macro(
+            name: "새로고침",
+            icon: "arrow.clockwise",
+            color: .teal,
+            size: .small,
+            keyCombo: KeyCombo(
+                keyCodes: [KeyCode.r],
+                modifiers: ModifierFlags.command.rawValue
+            )
+        ),
+        Macro(
+            name: "찾기",
+            icon: "magnifyingglass",
+            color: .gray,
+            size: .small,
+            keyCombo: KeyCombo(
+                keyCodes: [KeyCode.f],
+                modifiers: ModifierFlags.command.rawValue
+            )
+        ),
+
+        // 탭 관리
+        Macro(
+            name: "새 탭",
+            icon: "plus.square",
+            color: .pink,
+            size: .small,
+            keyCombo: KeyCombo(
+                keyCodes: [KeyCode.t],
+                modifiers: ModifierFlags.command.rawValue
+            )
+        ),
+        Macro(
+            name: "탭 닫기",
+            icon: "xmark.square",
+            color: .red,
+            size: .small,
+            keyCombo: KeyCombo(
+                keyCodes: [KeyCode.w],
+                modifiers: ModifierFlags.command.rawValue
+            )
+        ),
+    ]
+}
+
+// MARK: - Key Codes
+
+/// macOS 키 코드
+public enum KeyCode {
+    public static let a: UInt32 = 0
+    public static let s: UInt32 = 1
+    public static let d: UInt32 = 2
+    public static let f: UInt32 = 3
+    public static let h: UInt32 = 4
+    public static let g: UInt32 = 5
+    public static let z: UInt32 = 6
+    public static let x: UInt32 = 7
+    public static let c: UInt32 = 8
+    public static let v: UInt32 = 9
+    public static let b: UInt32 = 11
+    public static let q: UInt32 = 12
+    public static let w: UInt32 = 13
+    public static let e: UInt32 = 14
+    public static let r: UInt32 = 15
+    public static let y: UInt32 = 16
+    public static let t: UInt32 = 17
+    public static let num1: UInt32 = 18
+    public static let num2: UInt32 = 19
+    public static let num3: UInt32 = 20
+    public static let num4: UInt32 = 21
+    public static let num5: UInt32 = 23
+    public static let num6: UInt32 = 22
+    public static let num7: UInt32 = 26
+    public static let num8: UInt32 = 28
+    public static let num9: UInt32 = 25
+    public static let num0: UInt32 = 29
+    public static let space: UInt32 = 49
+    public static let returnKey: UInt32 = 36
+    public static let tab: UInt32 = 48
+    public static let delete: UInt32 = 51
+    public static let escape: UInt32 = 53
+    public static let leftArrow: UInt32 = 123
+    public static let rightArrow: UInt32 = 124
+    public static let downArrow: UInt32 = 125
+    public static let upArrow: UInt32 = 126
+}


### PR DESCRIPTION
## Summary
- 자주 쓰는 단축키를 모아놓은 매크로 패드를 Bento Grid UI로 구현
- 기본 매크로 12개 제공 (복사, 붙여넣기, 실행취소, 스크린샷 등)
- 편집 모드에서 매크로 삭제 가능

## Changes
### Shared
- `MacroMessages.swift`: Macro 데이터 모델 (이름, 아이콘, 색상, 크기, KeyCombo)
- `MacroColor`: 9가지 색상 (blue, purple, pink, red, orange, yellow, green, teal, gray)
- `MacroSize`: 3가지 크기 (small 1x1, medium 2x1, large 2x2)
- `KeyCode`: macOS 키 코드 상수
- `Macro.defaults`: 기본 매크로 12개

### iOS App
- `MacroFeature`: TCA Reducer (매크로 실행, 편집 모드, 삭제)
- `MacroView`: 전체 화면 매크로 뷰
- `MacroPadSection`: ProductivityView에 임베드되는 컴팩트 버전
- `MacroButton`: 그라디언트 배경, 아이콘, 이름 표시
- `ProductivityFeature/View`: MacroFeature 통합

## Test plan
- [ ] ProductivityView에서 매크로 패드 표시 확인
- [ ] 매크로 탭 시 Mac에서 해당 단축키 실행 확인
- [ ] 편집 버튼으로 편집 모드 진입/종료 확인
- [ ] 편집 모드에서 X 버튼으로 매크로 삭제 확인
- [ ] 다양한 크기의 매크로가 그리드에 올바르게 배치되는지 확인

Close #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)