### PR TITLE
[Feat]: 보이스 타이핑 (음성 → 텍스트 입력)

### DIFF
--- a/Projects/App/Sources/Features/Productivity/ProductivityFeature.swift
+++ b/Projects/App/Sources/Features/Productivity/ProductivityFeature.swift
@@ -9,6 +9,7 @@ public struct ProductivityFeature {
         public var runningApps: [AppInfo] = []
         public var isLoadingApps: Bool = false
         public var macro: MacroFeature.State = .init()
+        public var voiceTyping: VoiceTypingFeature.State = .init()
     }
 
     public enum Action: Equatable, Sendable {
@@ -28,6 +29,9 @@ public struct ProductivityFeature {
 
         // Macro
         case macro(MacroFeature.Action)
+
+        // Voice Typing
+        case voiceTyping(VoiceTypingFeature.Action)
     }
 
     @Dependency(\.connectionClient) var connectionClient
@@ -37,6 +41,10 @@ public struct ProductivityFeature {
     public var body: some ReducerOf<Self> {
         Scope(state: \.macro, action: \.macro) {
             MacroFeature()
+        }
+
+        Scope(state: \.voiceTyping, action: \.voiceTyping) {
+            VoiceTypingFeature()
         }
 
         Reduce { state, action in
@@ -92,6 +100,9 @@ public struct ProductivityFeature {
                 }
 
             case .macro:
+                return .none
+
+            case .voiceTyping:
                 return .none
             }
         }

--- a/Projects/App/Sources/Features/Productivity/ProductivityView.swift
+++ b/Projects/App/Sources/Features/Productivity/ProductivityView.swift
@@ -15,6 +15,9 @@ public struct ProductivityView: View {
                 // Macro Pad Section
                 macroSection
 
+                // Voice Typing Section
+                voiceTypingSection
+
                 // Siri Section
                 siriSection
 
@@ -37,6 +40,18 @@ public struct ProductivityView: View {
         MacroPadSection(
             store: store.scope(state: \.macro, action: \.macro)
         )
+    }
+
+    // MARK: - Voice Typing Section
+
+    @ViewBuilder
+    private var voiceTypingSection: some View {
+        VoiceTypingSection(
+            store: store.scope(state: \.voiceTyping, action: \.voiceTyping)
+        )
+        .padding()
+        .background(Color(.secondarySystemBackground).opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 16))
     }
 
     // MARK: - Siri Section

--- a/Projects/App/Sources/Features/VoiceTyping/VoiceTypingFeature.swift
+++ b/Projects/App/Sources/Features/VoiceTyping/VoiceTypingFeature.swift
@@ -1,0 +1,148 @@
+import ComposableArchitecture
+import Foundation
+import Speech
+
+@Reducer
+public struct VoiceTypingFeature {
+    @ObservableState
+    public struct State: Equatable {
+        public var isRecording: Bool = false
+        public var recognizedText: String = ""
+        public var authorizationStatus: AuthorizationStatus = .notDetermined
+        public var errorMessage: String?
+
+        public enum AuthorizationStatus: Equatable, Sendable {
+            case notDetermined
+            case authorized
+            case denied
+            case restricted
+        }
+
+        public init() {}
+    }
+
+    public enum Action: Equatable, Sendable {
+        case onAppear
+        case checkAuthorization
+        case authorizationResult(State.AuthorizationStatus)
+        case toggleRecording
+        case startRecording
+        case stopRecording
+        case recognitionEvent(SpeechRecognitionEvent)
+        case sendText
+        case clearText
+        case dismissError
+    }
+
+    @Dependency(\.connectionClient) var connectionClient
+
+    private let speechRecognizer = SpeechRecognizer()
+
+    public init() {}
+
+    public var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .onAppear:
+                return .send(.checkAuthorization)
+
+            case .checkAuthorization:
+                let recognizer = speechRecognizer
+                return .run { send in
+                    let speechStatus = await recognizer.requestAuthorization()
+                    let micStatus = await recognizer.requestMicrophoneAuthorization()
+
+                    let status: State.AuthorizationStatus
+                    if !micStatus {
+                        status = .denied
+                    } else {
+                        switch speechStatus {
+                        case .authorized:
+                            status = .authorized
+                        case .denied:
+                            status = .denied
+                        case .restricted:
+                            status = .restricted
+                        case .notDetermined:
+                            status = .notDetermined
+                        @unknown default:
+                            status = .denied
+                        }
+                    }
+                    await send(.authorizationResult(status))
+                }
+
+            case .authorizationResult(let status):
+                state.authorizationStatus = status
+                return .none
+
+            case .toggleRecording:
+                if state.isRecording {
+                    return .send(.stopRecording)
+                } else {
+                    return .send(.startRecording)
+                }
+
+            case .startRecording:
+                guard state.authorizationStatus == .authorized else {
+                    state.errorMessage = "음성 인식 권한이 필요합니다"
+                    return .none
+                }
+
+                state.isRecording = true
+                state.recognizedText = ""
+                state.errorMessage = nil
+
+                let recognizer = speechRecognizer
+                return .run { send in
+                    for await event in recognizer.startRecognition() {
+                        await send(.recognitionEvent(event))
+                    }
+                }
+
+            case .stopRecording:
+                state.isRecording = false
+                speechRecognizer.stopRecognition()
+                return .none
+
+            case .recognitionEvent(let event):
+                switch event {
+                case .recognized(let text, let isFinal):
+                    state.recognizedText = text
+                    if isFinal {
+                        state.isRecording = false
+                    }
+
+                case .error(let message):
+                    state.errorMessage = message
+                    state.isRecording = false
+
+                case .availabilityChanged(let available):
+                    if !available {
+                        state.errorMessage = "음성 인식을 사용할 수 없습니다"
+                        state.isRecording = false
+                    }
+                }
+                return .none
+
+            case .sendText:
+                guard !state.recognizedText.isEmpty else { return .none }
+
+                let text = state.recognizedText
+                let client = connectionClient
+
+                return .run { _ in
+                    await client.sendVoiceText(text, true)
+                }
+
+            case .clearText:
+                state.recognizedText = ""
+                return .none
+
+            case .dismissError:
+                state.errorMessage = nil
+                return .none
+            }
+        }
+    }
+}

--- a/Projects/App/Sources/Features/VoiceTyping/VoiceTypingView.swift
+++ b/Projects/App/Sources/Features/VoiceTyping/VoiceTypingView.swift
@@ -1,0 +1,245 @@
+import ComposableArchitecture
+import SwiftUI
+
+public struct VoiceTypingView: View {
+    @Bindable var store: StoreOf<VoiceTypingFeature>
+
+    public init(store: StoreOf<VoiceTypingFeature>) {
+        self.store = store
+    }
+
+    public var body: some View {
+        VStack(spacing: 24) {
+            // 상태 표시
+            statusIndicator
+
+            // 인식된 텍스트
+            recognizedTextView
+
+            // 컨트롤 버튼
+            controlButtons
+        }
+        .padding()
+        .onAppear {
+            store.send(.onAppear)
+        }
+        .alert(
+            "오류",
+            isPresented: .init(
+                get: { store.errorMessage != nil },
+                set: { if !$0 { store.send(.dismissError) } }
+            )
+        ) {
+            Button("확인") {
+                store.send(.dismissError)
+            }
+        } message: {
+            Text(store.errorMessage ?? "")
+        }
+    }
+
+    @ViewBuilder
+    private var statusIndicator: some View {
+        VStack(spacing: 12) {
+            ZStack {
+                // 배경 원
+                Circle()
+                    .fill(store.isRecording ? Color.red.opacity(0.2) : Color.gray.opacity(0.1))
+                    .frame(width: 120, height: 120)
+
+                // 펄스 애니메이션
+                if store.isRecording {
+                    PulseView()
+                }
+
+                // 마이크 아이콘
+                Image(systemName: store.isRecording ? "waveform" : "mic.fill")
+                    .font(.system(size: 40))
+                    .foregroundStyle(store.isRecording ? .red : .gray)
+                    .symbolEffect(.variableColor.iterative, isActive: store.isRecording)
+            }
+
+            Text(statusText)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var statusText: String {
+        switch store.authorizationStatus {
+        case .notDetermined:
+            return "권한 확인 중..."
+        case .authorized:
+            return store.isRecording ? "듣고 있어요..." : "마이크를 탭하여 시작"
+        case .denied:
+            return "권한이 거부됨"
+        case .restricted:
+            return "사용할 수 없음"
+        }
+    }
+
+    @ViewBuilder
+    private var recognizedTextView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("인식된 텍스트")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                if !store.recognizedText.isEmpty {
+                    Button {
+                        store.send(.clearText)
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            ScrollView {
+                Text(store.recognizedText.isEmpty ? "음성 인식 결과가 여기에 표시됩니다" : store.recognizedText)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .foregroundStyle(store.recognizedText.isEmpty ? .tertiary : .primary)
+            }
+            .frame(minHeight: 100, maxHeight: 200)
+            .padding()
+            .background(Color(.secondarySystemBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+    }
+
+    @ViewBuilder
+    private var controlButtons: some View {
+        HStack(spacing: 16) {
+            // 녹음 토글 버튼
+            Button {
+                store.send(.toggleRecording)
+            } label: {
+                Label(
+                    store.isRecording ? "중지" : "시작",
+                    systemImage: store.isRecording ? "stop.fill" : "mic.fill"
+                )
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(store.isRecording ? .red : .blue)
+            .controlSize(.large)
+            .disabled(store.authorizationStatus != .authorized)
+
+            // 전송 버튼
+            Button {
+                store.send(.sendText)
+            } label: {
+                Label("전송", systemImage: "paperplane.fill")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.green)
+            .controlSize(.large)
+            .disabled(store.recognizedText.isEmpty || store.isRecording)
+        }
+    }
+}
+
+// MARK: - Pulse Animation View
+
+private struct PulseView: View {
+    @State private var isAnimating = false
+
+    var body: some View {
+        ZStack {
+            ForEach(0..<3, id: \.self) { index in
+                Circle()
+                    .stroke(Color.red.opacity(0.3), lineWidth: 2)
+                    .frame(width: 120, height: 120)
+                    .scaleEffect(isAnimating ? 1.5 : 1.0)
+                    .opacity(isAnimating ? 0 : 0.5)
+                    .animation(
+                        .easeOut(duration: 1.5)
+                            .repeatForever(autoreverses: false)
+                            .delay(Double(index) * 0.5),
+                        value: isAnimating
+                    )
+            }
+        }
+        .onAppear {
+            isAnimating = true
+        }
+    }
+}
+
+// MARK: - Voice Typing Section (for ProductivityView)
+
+public struct VoiceTypingSection: View {
+    let store: StoreOf<VoiceTypingFeature>
+
+    public init(store: StoreOf<VoiceTypingFeature>) {
+        self.store = store
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("보이스 타이핑", systemImage: "mic.fill")
+                .font(.headline)
+
+            HStack(spacing: 12) {
+                // 녹음 버튼
+                Button {
+                    store.send(.toggleRecording)
+                } label: {
+                    VStack(spacing: 8) {
+                        Image(systemName: store.isRecording ? "stop.fill" : "mic.fill")
+                            .font(.title2)
+                            .symbolEffect(.variableColor.iterative, isActive: store.isRecording)
+
+                        Text(store.isRecording ? "중지" : "녹음")
+                            .font(.caption)
+                    }
+                    .frame(width: 70, height: 70)
+                    .background(store.isRecording ? Color.red : Color.blue)
+                    .foregroundStyle(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+                }
+                .buttonStyle(.plain)
+                .disabled(store.authorizationStatus != .authorized)
+
+                // 텍스트 미리보기 및 전송
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(store.recognizedText.isEmpty ? "음성을 인식하면 여기에 표시됩니다" : store.recognizedText)
+                        .font(.subheadline)
+                        .foregroundStyle(store.recognizedText.isEmpty ? .tertiary : .primary)
+                        .lineLimit(2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    if !store.recognizedText.isEmpty && !store.isRecording {
+                        Button {
+                            store.send(.sendText)
+                        } label: {
+                            Label("Mac으로 전송", systemImage: "paperplane.fill")
+                                .font(.caption)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                    }
+                }
+                .padding()
+                .background(Color(.secondarySystemBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+        }
+        .onAppear {
+            store.send(.onAppear)
+        }
+    }
+}
+
+#Preview {
+    VoiceTypingView(
+        store: Store(initialState: VoiceTypingFeature.State()) {
+            VoiceTypingFeature()
+        }
+    )
+}

--- a/Projects/App/Sources/Services/ConnectionClient.swift
+++ b/Projects/App/Sources/Services/ConnectionClient.swift
@@ -23,6 +23,7 @@ public struct ConnectionClient: Sendable {
     public var requestAppList: @Sendable () async -> Void
     public var sendAppFocus: @Sendable (String, UInt32) async -> Void
     public var sendSiriCommand: @Sendable (SiriCommand.Action, String) async -> Void
+    public var sendVoiceText: @Sendable (String, Bool) async -> Void
 }
 
 // MARK: - Events
@@ -79,7 +80,8 @@ extension ConnectionClient: DependencyKey {
             sendWindowSnap: { pos in await actor.sendWindowSnap(position: pos) },
             requestAppList: { await actor.requestAppList() },
             sendAppFocus: { bundleID, pid in await actor.sendAppFocus(bundleID: bundleID, pid: pid) },
-            sendSiriCommand: { action, text in await actor.sendSiriCommand(action: action, text: text) }
+            sendSiriCommand: { action, text in await actor.sendSiriCommand(action: action, text: text) },
+            sendVoiceText: { text, isFinal in await actor.sendVoiceText(text: text, isFinal: isFinal) }
         )
     }
 
@@ -98,7 +100,8 @@ extension ConnectionClient: DependencyKey {
             sendWindowSnap: { _ in },
             requestAppList: {},
             sendAppFocus: { _, _ in },
-            sendSiriCommand: { _, _ in }
+            sendSiriCommand: { _, _ in },
+            sendVoiceText: { _, _ in }
         )
     }
 }
@@ -209,6 +212,10 @@ private actor ConnectionActor: SnapClientDelegate, BonjourBrowserDelegate {
 
     func sendSiriCommand(action: SiriCommand.Action, text: String) {
         client?.sendSiriCommand(action: action, text: text)
+    }
+
+    func sendVoiceText(text: String, isFinal: Bool) {
+        client?.sendVoiceText(text: text, isFinal: isFinal)
     }
 
     // MARK: - SnapClientDelegate

--- a/Projects/App/Sources/Services/SnapClient.swift
+++ b/Projects/App/Sources/Services/SnapClient.swift
@@ -154,6 +154,14 @@ public final class SnapClient: @unchecked Sendable {
         tcpConnection?.send(command, type: .siriCommand)
     }
 
+    /// 음성 텍스트 전송 (TCP)
+    public func sendVoiceText(text: String, isFinal: Bool) {
+        guard isConnected else { return }
+
+        let voiceText = VoiceText(text: text, isFinal: isFinal)
+        tcpConnection?.send(voiceText, type: .voiceText)
+    }
+
     // MARK: - Private Methods
 
     private static func getDeviceID() -> String {

--- a/Projects/App/Sources/Services/SpeechRecognizer.swift
+++ b/Projects/App/Sources/Services/SpeechRecognizer.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Speech
+import AVFoundation
+
+/// 음성 인식 결과 이벤트
+public enum SpeechRecognitionEvent: Equatable, Sendable {
+    case recognized(text: String, isFinal: Bool)
+    case error(String)
+    case availabilityChanged(Bool)
+}
+
+/// 음성 인식 서비스
+public final class SpeechRecognizer: @unchecked Sendable {
+    // MARK: - Properties
+
+    private let speechRecognizer: SFSpeechRecognizer?
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    private var recognitionTask: SFSpeechRecognitionTask?
+    private let audioEngine = AVAudioEngine()
+
+    private var isRecording = false
+
+    // MARK: - Initialization
+
+    public init(locale: Locale = .current) {
+        self.speechRecognizer = SFSpeechRecognizer(locale: locale)
+    }
+
+    // MARK: - Authorization
+
+    /// 음성 인식 권한 요청
+    public func requestAuthorization() async -> SFSpeechRecognizerAuthorizationStatus {
+        await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                continuation.resume(returning: status)
+            }
+        }
+    }
+
+    /// 마이크 권한 요청
+    public func requestMicrophoneAuthorization() async -> Bool {
+        await withCheckedContinuation { continuation in
+            AVAudioApplication.requestRecordPermission { granted in
+                continuation.resume(returning: granted)
+            }
+        }
+    }
+
+    /// 현재 권한 상태
+    public var authorizationStatus: SFSpeechRecognizerAuthorizationStatus {
+        SFSpeechRecognizer.authorizationStatus()
+    }
+
+    /// 음성 인식 사용 가능 여부
+    public var isAvailable: Bool {
+        speechRecognizer?.isAvailable ?? false
+    }
+
+    // MARK: - Recognition
+
+    /// 음성 인식 시작
+    public func startRecognition() -> AsyncStream<SpeechRecognitionEvent> {
+        AsyncStream { continuation in
+            do {
+                try self.startRecognitionInternal(continuation: continuation)
+
+                continuation.onTermination = { [weak self] _ in
+                    self?.stopRecognition()
+                }
+            } catch {
+                continuation.yield(.error(error.localizedDescription))
+                continuation.finish()
+            }
+        }
+    }
+
+    /// 음성 인식 중지
+    public func stopRecognition() {
+        guard isRecording else { return }
+
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+        recognitionRequest?.endAudio()
+        recognitionTask?.cancel()
+
+        recognitionRequest = nil
+        recognitionTask = nil
+        isRecording = false
+    }
+
+    // MARK: - Private
+
+    private func startRecognitionInternal(continuation: AsyncStream<SpeechRecognitionEvent>.Continuation) throws {
+        guard let speechRecognizer = speechRecognizer, speechRecognizer.isAvailable else {
+            throw SpeechRecognizerError.notAvailable
+        }
+
+        guard !isRecording else {
+            throw SpeechRecognizerError.alreadyRecording
+        }
+
+        // 기존 태스크 정리
+        recognitionTask?.cancel()
+        recognitionTask = nil
+
+        // 오디오 세션 설정
+        let audioSession = AVAudioSession.sharedInstance()
+        try audioSession.setCategory(.record, mode: .measurement, options: .duckOthers)
+        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+
+        // 인식 요청 생성
+        recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
+        guard let recognitionRequest = recognitionRequest else {
+            throw SpeechRecognizerError.requestCreationFailed
+        }
+
+        recognitionRequest.shouldReportPartialResults = true
+        recognitionRequest.requiresOnDeviceRecognition = false
+
+        // 인식 태스크 시작
+        recognitionTask = speechRecognizer.recognitionTask(with: recognitionRequest) { [weak self] result, error in
+            guard self != nil else { return }
+
+            if let result = result {
+                let text = result.bestTranscription.formattedString
+                let isFinal = result.isFinal
+                continuation.yield(.recognized(text: text, isFinal: isFinal))
+
+                if isFinal {
+                    continuation.finish()
+                }
+            }
+
+            if let error = error {
+                continuation.yield(.error(error.localizedDescription))
+                continuation.finish()
+            }
+        }
+
+        // 오디오 입력 설정
+        let inputNode = audioEngine.inputNode
+        let recordingFormat = inputNode.outputFormat(forBus: 0)
+
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { buffer, _ in
+            self.recognitionRequest?.append(buffer)
+        }
+
+        audioEngine.prepare()
+        try audioEngine.start()
+
+        isRecording = true
+    }
+}
+
+// MARK: - Errors
+
+public enum SpeechRecognizerError: LocalizedError {
+    case notAvailable
+    case alreadyRecording
+    case requestCreationFailed
+    case audioEngineError
+
+    public var errorDescription: String? {
+        switch self {
+        case .notAvailable:
+            return "음성 인식을 사용할 수 없습니다"
+        case .alreadyRecording:
+            return "이미 녹음 중입니다"
+        case .requestCreationFailed:
+            return "음성 인식 요청을 생성할 수 없습니다"
+        case .audioEngineError:
+            return "오디오 엔진 오류가 발생했습니다"
+        }
+    }
+}

--- a/Projects/MacReceiver/Sources/MacReceiverApp.swift
+++ b/Projects/MacReceiver/Sources/MacReceiverApp.swift
@@ -438,8 +438,10 @@ final class ServerManager: ObservableObject {
             logPacket("Presentation: \(pres.command)")
 
         case .voiceText(let voice, _):
-            // TODO: Type text
-            logPacket("VoiceText: \(voice.text)")
+            if voice.isFinal && !voice.text.isEmpty {
+                InputSimulator.shared.typeText(voice.text)
+            }
+            logPacket("VoiceText: \(voice.text) (final: \(voice.isFinal))")
 
         case .siriCommand(let command, _):
             SiriController.shared.execute(command: command)

--- a/Projects/MacReceiver/Sources/Server/InputSimulator.swift
+++ b/Projects/MacReceiver/Sources/Server/InputSimulator.swift
@@ -91,6 +91,32 @@ public final class InputSimulator: @unchecked Sendable {
         setModifiers(modifiers, keyDown: false)
     }
 
+    /// 텍스트 입력 (유니코드 문자열)
+    public func typeText(_ text: String) {
+        for character in text {
+            typeCharacter(character)
+        }
+    }
+
+    /// 단일 문자 입력
+    private func typeCharacter(_ character: Character) {
+        let string = String(character)
+        guard let unicodeScalar = string.unicodeScalars.first else { return }
+
+        // CGEventKeyboardSetUnicodeString을 사용하여 유니코드 문자 입력
+        guard let keyDownEvent = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true),
+              let keyUpEvent = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false) else {
+            return
+        }
+
+        var unicodeChar = UniChar(unicodeScalar.value)
+        keyDownEvent.keyboardSetUnicodeString(stringLength: 1, unicodeString: &unicodeChar)
+        keyUpEvent.keyboardSetUnicodeString(stringLength: 1, unicodeString: &unicodeChar)
+
+        keyDownEvent.post(tap: .cghidEventTap)
+        keyUpEvent.post(tap: .cghidEventTap)
+    }
+
     // MARK: - Private Helpers
 
     private func currentMouseLocation() -> CGPoint {


### PR DESCRIPTION
## Summary
- iOS에서 SFSpeechRecognizer를 사용한 음성 인식 기능 구현
- 인식된 텍스트를 Mac으로 전송하여 CGEvent로 입력
- ProductivityView에 VoiceTypingSection 통합

## Changes
### iOS App
- `SpeechRecognizer.swift`: SFSpeechRecognizer 래퍼 서비스
- `VoiceTypingFeature.swift`: TCA reducer (권한 요청, 녹음 상태 관리)
- `VoiceTypingView.swift`: 녹음 UI + 펄스 애니메이션
- `ConnectionClient.swift`: sendVoiceText 추가
- `SnapClient.swift`: sendVoiceText 메서드 추가
- `ProductivityFeature/View`: VoiceTyping 통합

### macOS MacReceiver
- `InputSimulator.swift`: typeText() 메서드 추가 (유니코드 지원)
- `MacReceiverApp.swift`: voiceText 패킷 처리

## Test plan
- [ ] iOS에서 마이크/음성 인식 권한 요청 확인
- [ ] 녹음 버튼 탭 시 음성 인식 시작 확인
- [ ] 인식된 텍스트가 실시간으로 표시되는지 확인
- [ ] 전송 버튼 클릭 시 Mac에서 텍스트 입력 확인
- [ ] 한글, 영어, 특수문자 모두 입력 확인

Close #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)