### PR TITLE
[Feat]: 자이로스코프 레이저 포인터 (Air Mouse)

### DIFF
--- a/Projects/App/Sources/Features/LaserPointer/LaserPointerFeature.swift
+++ b/Projects/App/Sources/Features/LaserPointer/LaserPointerFeature.swift
@@ -1,0 +1,101 @@
+import ComposableArchitecture
+import Foundation
+import Shared
+
+@Reducer
+public struct LaserPointerFeature {
+    @ObservableState
+    public struct State: Equatable {
+        public var isActive: Bool = false
+        public var isCalibrated: Bool = false
+        public var sensitivity: Float = 15.0
+        public var errorMessage: String?
+
+        public init() {}
+    }
+
+    public enum Action: Equatable, Sendable {
+        case toggleActive
+        case startPointing
+        case stopPointing
+        case calibrate
+        case setSensitivity(Float)
+        case motionEvent(MotionEvent)
+        case dismissError
+    }
+
+    @Dependency(\.connectionClient) var connectionClient
+
+    private let motionManager = MotionManager()
+
+    public init() {}
+
+    public var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .toggleActive:
+                if state.isActive {
+                    return .send(.stopPointing)
+                } else {
+                    return .send(.startPointing)
+                }
+
+            case .startPointing:
+                guard motionManager.isAvailable else {
+                    state.errorMessage = "자이로스코프를 사용할 수 없습니다"
+                    return .none
+                }
+
+                state.isActive = true
+                state.errorMessage = nil
+
+                // 시작할 때 자동 캘리브레이션
+                motionManager.calibrate()
+                state.isCalibrated = true
+
+                let manager = motionManager
+                return .run { send in
+                    for await event in manager.startUpdates() {
+                        await send(.motionEvent(event))
+                    }
+                }
+
+            case .stopPointing:
+                state.isActive = false
+                state.isCalibrated = false
+                motionManager.stopUpdates()
+                return .none
+
+            case .calibrate:
+                motionManager.calibrate()
+                state.isCalibrated = true
+                return .none
+
+            case .setSensitivity(let value):
+                state.sensitivity = value
+                motionManager.setSensitivity(value)
+                return .none
+
+            case .motionEvent(let event):
+                switch event {
+                case .update(let gyroData):
+                    guard state.isActive else { return .none }
+
+                    let client = connectionClient
+                    return .run { _ in
+                        await client.sendGyroData(gyroData)
+                    }
+
+                case .error(let message):
+                    state.errorMessage = message
+                    state.isActive = false
+                }
+                return .none
+
+            case .dismissError:
+                state.errorMessage = nil
+                return .none
+            }
+        }
+    }
+}

--- a/Projects/App/Sources/Features/LaserPointer/LaserPointerView.swift
+++ b/Projects/App/Sources/Features/LaserPointer/LaserPointerView.swift
@@ -1,0 +1,263 @@
+import ComposableArchitecture
+import SwiftUI
+
+public struct LaserPointerView: View {
+    @Bindable var store: StoreOf<LaserPointerFeature>
+
+    public init(store: StoreOf<LaserPointerFeature>) {
+        self.store = store
+    }
+
+    public var body: some View {
+        VStack(spacing: 24) {
+            // 상태 표시
+            statusIndicator
+
+            // 메인 버튼
+            laserButton
+
+            // 감도 조절
+            sensitivityControl
+
+            // 캘리브레이션 버튼
+            calibrateButton
+        }
+        .padding()
+        .alert(
+            "오류",
+            isPresented: .init(
+                get: { store.errorMessage != nil },
+                set: { if !$0 { store.send(.dismissError) } }
+            )
+        ) {
+            Button("확인") {
+                store.send(.dismissError)
+            }
+        } message: {
+            Text(store.errorMessage ?? "")
+        }
+    }
+
+    @ViewBuilder
+    private var statusIndicator: some View {
+        VStack(spacing: 8) {
+            Text(store.isActive ? "레이저 활성화" : "레이저 대기")
+                .font(.headline)
+                .foregroundStyle(store.isActive ? .red : .secondary)
+
+            if store.isActive && store.isCalibrated {
+                Text("기기를 움직여 커서를 이동하세요")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var laserButton: some View {
+        Button {
+            store.send(.toggleActive)
+        } label: {
+            ZStack {
+                // 배경 글로우
+                if store.isActive {
+                    Circle()
+                        .fill(Color.red.opacity(0.3))
+                        .frame(width: 200, height: 200)
+                        .blur(radius: 30)
+                }
+
+                // 메인 버튼
+                Circle()
+                    .fill(
+                        store.isActive
+                            ? LinearGradient(
+                                colors: [.red, .orange],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
+                            : LinearGradient(
+                                colors: [Color(.systemGray4), Color(.systemGray5)],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
+                    )
+                    .frame(width: 160, height: 160)
+                    .shadow(
+                        color: store.isActive ? .red.opacity(0.5) : .clear,
+                        radius: 20
+                    )
+
+                // 아이콘
+                VStack(spacing: 12) {
+                    Image(systemName: "scope")
+                        .font(.system(size: 50))
+                        .foregroundStyle(.white)
+                        .symbolEffect(.pulse, isActive: store.isActive)
+
+                    Text(store.isActive ? "누르고 있기" : "터치하여 시작")
+                        .font(.caption)
+                        .fontWeight(.bold)
+                        .foregroundStyle(.white.opacity(0.8))
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private var sensitivityControl: some View {
+        VStack(spacing: 8) {
+            HStack {
+                Text("감도")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                Text("\(Int(store.sensitivity))")
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+                    .monospacedDigit()
+            }
+
+            Slider(
+                value: Binding(
+                    get: { Double(store.sensitivity) },
+                    set: { store.send(.setSensitivity(Float($0))) }
+                ),
+                in: 1...50,
+                step: 1
+            )
+            .tint(.red)
+        }
+        .padding()
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    @ViewBuilder
+    private var calibrateButton: some View {
+        Button {
+            store.send(.calibrate)
+        } label: {
+            Label("현재 위치로 기준점 설정", systemImage: "scope")
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.bordered)
+        .disabled(!store.isActive)
+    }
+}
+
+// MARK: - Laser Pointer Section (for TrackpadView)
+
+public struct LaserPointerSection: View {
+    let store: StoreOf<LaserPointerFeature>
+
+    public init(store: StoreOf<LaserPointerFeature>) {
+        self.store = store
+    }
+
+    public var body: some View {
+        VStack(spacing: 16) {
+            // 모드 토글
+            HStack {
+                Label("레이저 포인터", systemImage: "scope")
+                    .font(.headline)
+
+                Spacer()
+
+                Toggle("", isOn: Binding(
+                    get: { store.isActive },
+                    set: { _ in store.send(.toggleActive) }
+                ))
+                .labelsHidden()
+                .tint(.red)
+            }
+
+            if store.isActive {
+                // 활성화 상태
+                VStack(spacing: 16) {
+                    // 큰 터치 영역
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 24)
+                            .fill(Color.red.opacity(0.1))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 24)
+                                    .strokeBorder(Color.red.opacity(0.3), lineWidth: 2)
+                            )
+
+                        VStack(spacing: 12) {
+                            Image(systemName: "scope")
+                                .font(.system(size: 40))
+                                .foregroundStyle(.red)
+                                .symbolEffect(.pulse)
+
+                            Text("기기를 움직여 커서 제어")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+
+                            // 캘리브레이션 버튼
+                            Button {
+                                store.send(.calibrate)
+                            } label: {
+                                Label("기준점 재설정", systemImage: "arrow.counterclockwise")
+                                    .font(.caption)
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                        }
+                    }
+                    .frame(height: 200)
+
+                    // 감도 슬라이더
+                    HStack {
+                        Image(systemName: "tortoise")
+                            .foregroundStyle(.secondary)
+
+                        Slider(
+                            value: Binding(
+                                get: { Double(store.sensitivity) },
+                                set: { store.send(.setSensitivity(Float($0))) }
+                            ),
+                            in: 1...50
+                        )
+                        .tint(.red)
+
+                        Image(systemName: "hare")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            } else {
+                // 비활성화 상태 - 안내
+                HStack(spacing: 12) {
+                    Image(systemName: "iphone.gen3.radiowaves.left.and.right")
+                        .font(.system(size: 32))
+                        .foregroundStyle(.red)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Air Mouse 모드")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        Text("iPhone을 허공에 움직여 Mac 커서를 제어합니다")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer()
+                }
+                .padding()
+                .background(Color(.tertiarySystemBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+        }
+    }
+}
+
+#Preview {
+    LaserPointerView(
+        store: Store(initialState: LaserPointerFeature.State()) {
+            LaserPointerFeature()
+        }
+    )
+}

--- a/Projects/App/Sources/Features/Trackpad/TrackpadFeature.swift
+++ b/Projects/App/Sources/Features/Trackpad/TrackpadFeature.swift
@@ -13,6 +13,7 @@ public struct TrackpadFeature {
         public var scrollSensitivity: Double = 1.0
         public var isNaturalScrolling: Bool = true
         public var isTapToClick: Bool = true
+        public var laserPointer: LaserPointerFeature.State = .init()
 
         public init() {}
     }
@@ -61,6 +62,9 @@ public struct TrackpadFeature {
             isNaturalScrolling: Bool,
             isTapToClick: Bool
         )
+
+        // Laser Pointer
+        case laserPointer(LaserPointerFeature.Action)
     }
 
     @Dependency(\.connectionClient) var connectionClient
@@ -68,12 +72,22 @@ public struct TrackpadFeature {
     public init() {}
 
     public var body: some ReducerOf<Self> {
+        Scope(state: \.laserPointer, action: \.laserPointer) {
+            LaserPointerFeature()
+        }
+
         Reduce { state, action in
             let client = connectionClient
 
             switch action {
             case .modeChanged(let mode):
                 state.mode = mode
+                // 모드 변경 시 레이저 포인터 상태 동기화
+                if mode == .laser && !state.laserPointer.isActive {
+                    return .send(.laserPointer(.startPointing))
+                } else if mode == .trackpad && state.laserPointer.isActive {
+                    return .send(.laserPointer(.stopPointing))
+                }
                 return .none
 
             case .touchBegan(let position):
@@ -162,6 +176,9 @@ public struct TrackpadFeature {
                 state.scrollSensitivity = scrollSensitivity
                 state.isNaturalScrolling = isNaturalScrolling
                 state.isTapToClick = isTapToClick
+                return .none
+
+            case .laserPointer:
                 return .none
             }
         }

--- a/Projects/App/Sources/Features/Trackpad/TrackpadView.swift
+++ b/Projects/App/Sources/Features/Trackpad/TrackpadView.swift
@@ -318,9 +318,10 @@ struct TrackpadTouchArea: View {
 
 struct LaserControlArea: View {
     let store: StoreOf<TrackpadFeature>
-    @State private var isHolding = false
 
     var body: some View {
+        let isActive = store.laserPointer.isActive
+
         ZStack {
             // Background
             RoundedRectangle(cornerRadius: 24)
@@ -341,7 +342,7 @@ struct LaserControlArea: View {
                 // Laser Button
                 ZStack {
                     // Outer glow (pulsing when active)
-                    if isHolding {
+                    if isActive {
                         Circle()
                             .fill(Color.red.opacity(0.2))
                             .frame(width: 220, height: 220)
@@ -351,50 +352,80 @@ struct LaserControlArea: View {
 
                     // Button shadow glow
                     Circle()
-                        .fill(Color.red.opacity(isHolding ? 0.5 : 0))
+                        .fill(Color.red.opacity(isActive ? 0.5 : 0))
                         .frame(width: 180, height: 180)
                         .blur(radius: 30)
 
                     // Main button
                     Circle()
-                        .fill(isHolding ? Color.red : Color(.tertiarySystemBackground))
+                        .fill(isActive ? Color.red : Color(.tertiarySystemBackground))
                         .frame(width: 160, height: 160)
                         .overlay(
                             Circle()
                                 .strokeBorder(
-                                    isHolding ? Color.red.opacity(0.6) : Color(.separator),
+                                    isActive ? Color.red.opacity(0.6) : Color(.separator),
                                     lineWidth: 2
                                 )
                         )
-                        .scaleEffect(isHolding ? 0.95 : 1.0)
+                        .scaleEffect(isActive ? 0.95 : 1.0)
 
                     VStack(spacing: 8) {
                         Image(systemName: "scope")
                             .font(.system(size: 44, weight: .medium))
-                            .foregroundStyle(isHolding ? .white : .red)
+                            .foregroundStyle(isActive ? .white : .red)
+                            .symbolEffect(.pulse, isActive: isActive)
 
-                        Text(isHolding ? "GYRO ACTIVE" : "HOLD TO MOVE")
+                        Text(isActive ? "GYRO ACTIVE" : "TAP TO START")
                             .font(.caption.weight(.bold))
-                            .foregroundStyle(isHolding ? .white : Color(.secondaryLabel))
+                            .foregroundStyle(isActive ? .white : Color(.secondaryLabel))
                             .tracking(1)
                     }
                 }
-                .animation(.spring(response: 0.25, dampingFraction: 0.6), value: isHolding)
-                .gesture(
-                    DragGesture(minimumDistance: 0)
-                        .onChanged { _ in
-                            if !isHolding {
-                                isHolding = true
-                            }
-                        }
-                        .onEnded { _ in
-                            isHolding = false
-                        }
-                )
+                .animation(.spring(response: 0.25, dampingFraction: 0.6), value: isActive)
+                .onTapGesture {
+                    store.send(.laserPointer(.toggleActive))
+                }
                 .accessibilityLabel("레이저 포인터 버튼")
-                .accessibilityHint("길게 눌러 자이로스코프로 마우스를 제어합니다")
+                .accessibilityHint("탭하여 자이로스코프 마우스 제어를 시작/중지합니다")
 
                 Spacer()
+
+                // Sensitivity & Calibrate
+                if isActive {
+                    VStack(spacing: 12) {
+                        // Sensitivity slider
+                        HStack {
+                            Image(systemName: "tortoise")
+                                .foregroundStyle(.secondary)
+                                .font(.caption)
+
+                            Slider(
+                                value: Binding(
+                                    get: { Double(store.laserPointer.sensitivity) },
+                                    set: { store.send(.laserPointer(.setSensitivity(Float($0)))) }
+                                ),
+                                in: 1...50
+                            )
+                            .tint(.red)
+
+                            Image(systemName: "hare")
+                                .foregroundStyle(.secondary)
+                                .font(.caption)
+                        }
+
+                        // Calibrate button
+                        Button {
+                            store.send(.laserPointer(.calibrate))
+                        } label: {
+                            Label("기준점 재설정", systemImage: "scope")
+                                .font(.caption)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+                    .padding(.horizontal)
+                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+                }
             }
             .padding()
         }

--- a/Projects/App/Sources/Services/ConnectionClient.swift
+++ b/Projects/App/Sources/Services/ConnectionClient.swift
@@ -16,6 +16,7 @@ public struct ConnectionClient: Sendable {
     public var sendMouseMove: @Sendable (Float, Float) async -> Void
     public var sendMouseClick: @Sendable (MouseClick.Button, MouseClick.Action) async -> Void
     public var sendScroll: @Sendable (Float, Float, Bool) async -> Void
+    public var sendGyroData: @Sendable (GyroData) async -> Void
     public var sendKeyEvent: @Sendable (UInt32, KeyEvent.Action, UInt32) async -> Void
     public var sendKeyCombo: @Sendable ([UInt32], UInt32) async -> Void
     public var sendMediaControl: @Sendable (MediaControl.Command, Float) async -> Void
@@ -74,6 +75,7 @@ extension ConnectionClient: DependencyKey {
             sendMouseMove: { dx, dy in await actor.sendMouseMove(deltaX: dx, deltaY: dy) },
             sendMouseClick: { button, action in await actor.sendMouseClick(button: button, action: action) },
             sendScroll: { dx, dy, inertia in await actor.sendScroll(deltaX: dx, deltaY: dy, isInertia: inertia) },
+            sendGyroData: { gyroData in await actor.sendGyroData(gyroData) },
             sendKeyEvent: { code, action, mods in await actor.sendKeyEvent(keyCode: code, action: action, modifiers: mods) },
             sendKeyCombo: { codes, mods in await actor.sendKeyCombo(keyCodes: codes, modifiers: mods) },
             sendMediaControl: { cmd, vol in await actor.sendMediaControl(command: cmd, volume: vol) },
@@ -94,6 +96,7 @@ extension ConnectionClient: DependencyKey {
             sendMouseMove: { _, _ in },
             sendMouseClick: { _, _ in },
             sendScroll: { _, _, _ in },
+            sendGyroData: { _ in },
             sendKeyEvent: { _, _, _ in },
             sendKeyCombo: { _, _ in },
             sendMediaControl: { _, _ in },
@@ -184,6 +187,10 @@ private actor ConnectionActor: SnapClientDelegate, BonjourBrowserDelegate {
 
     func sendScroll(deltaX: Float, deltaY: Float, isInertia: Bool) {
         client?.sendScroll(deltaX: deltaX, deltaY: deltaY, isInertia: isInertia)
+    }
+
+    func sendGyroData(_ gyroData: GyroData) {
+        client?.sendGyroData(gyroData)
     }
 
     func sendKeyEvent(keyCode: UInt32, action: KeyEvent.Action, modifiers: UInt32) {

--- a/Projects/App/Sources/Services/MotionManager.swift
+++ b/Projects/App/Sources/Services/MotionManager.swift
@@ -1,0 +1,117 @@
+import CoreMotion
+import Foundation
+import Shared
+
+/// 모션 이벤트
+public enum MotionEvent: Equatable, Sendable {
+    case update(GyroData)
+    case error(String)
+}
+
+/// CoreMotion 기반 모션 매니저
+public final class MotionManager: @unchecked Sendable {
+    // MARK: - Properties
+
+    private let motionManager = CMMotionManager()
+    private var referenceAttitude: CMAttitude?
+    private var sensitivity: Float = 15.0
+
+    private let updateInterval: TimeInterval = 1.0 / 60.0 // 60Hz
+
+    // MARK: - Initialization
+
+    public init() {}
+
+    // MARK: - Public Methods
+
+    /// 모션 업데이트 시작
+    public func startUpdates() -> AsyncStream<MotionEvent> {
+        AsyncStream { continuation in
+            guard motionManager.isDeviceMotionAvailable else {
+                continuation.yield(.error("Device motion is not available"))
+                continuation.finish()
+                return
+            }
+
+            motionManager.deviceMotionUpdateInterval = updateInterval
+
+            motionManager.startDeviceMotionUpdates(
+                using: .xArbitraryZVertical,
+                to: .main
+            ) { [weak self] motion, error in
+                guard let self = self else { return }
+
+                if let error = error {
+                    continuation.yield(.error(error.localizedDescription))
+                    return
+                }
+
+                guard let motion = motion else { return }
+
+                let gyroData = self.processMotion(motion)
+                continuation.yield(.update(gyroData))
+            }
+
+            continuation.onTermination = { [weak self] _ in
+                self?.stopUpdates()
+            }
+        }
+    }
+
+    /// 모션 업데이트 중지
+    public func stopUpdates() {
+        motionManager.stopDeviceMotionUpdates()
+        referenceAttitude = nil
+    }
+
+    /// 기준점 캘리브레이션 (현재 위치를 기준으로 설정)
+    public func calibrate() {
+        referenceAttitude = motionManager.deviceMotion?.attitude.copy() as? CMAttitude
+    }
+
+    /// 감도 설정 (1.0 ~ 50.0)
+    public func setSensitivity(_ value: Float) {
+        sensitivity = max(1.0, min(50.0, value))
+    }
+
+    /// 현재 감도
+    public var currentSensitivity: Float {
+        sensitivity
+    }
+
+    /// Device motion 사용 가능 여부
+    public var isAvailable: Bool {
+        motionManager.isDeviceMotionAvailable
+    }
+
+    // MARK: - Private Methods
+
+    private func processMotion(_ motion: CMDeviceMotion) -> GyroData {
+        // 기준점 대비 상대 attitude 계산
+        let attitude = motion.attitude
+
+        if let reference = referenceAttitude {
+            attitude.multiply(byInverseOf: reference)
+        }
+
+        // Rotation rate (rad/s)
+        let rotationRate = Vector3(
+            x: Float(motion.rotationRate.x),
+            y: Float(motion.rotationRate.y),
+            z: Float(motion.rotationRate.z)
+        )
+
+        // Attitude (pitch, roll, yaw in radians)
+        let attitudeVector = Vector3(
+            x: Float(attitude.pitch),
+            y: Float(attitude.roll),
+            z: Float(attitude.yaw)
+        )
+
+        return GyroData(
+            rotationRate: rotationRate,
+            attitude: attitudeVector,
+            sensitivity: sensitivity
+        )
+    }
+}

--- a/Projects/App/Sources/Services/SnapClient.swift
+++ b/Projects/App/Sources/Services/SnapClient.swift
@@ -98,6 +98,13 @@ public final class SnapClient: @unchecked Sendable {
         udpSocket?.send(scroll, type: .scroll)
     }
 
+    /// 자이로 데이터 전송 (UDP)
+    public func sendGyroData(_ gyroData: GyroData) {
+        guard isConnected else { return }
+
+        udpSocket?.send(gyroData, type: .gyroData)
+    }
+
     /// 키 이벤트 전송 (TCP)
     public func sendKeyEvent(keyCode: UInt32, action: KeyEvent.Action, modifiers: UInt32 = 0) {
         guard isConnected else { return }

--- a/Projects/MacReceiver/Sources/MacReceiverApp.swift
+++ b/Projects/MacReceiver/Sources/MacReceiverApp.swift
@@ -400,6 +400,13 @@ final class ServerManager: ObservableObject {
             )
             logPacket("Scroll: dx=\(scroll.deltaX), dy=\(scroll.deltaY)")
 
+        case .gyroData(let gyro, _):
+            // attitude.y (roll) → 수평 이동 (X)
+            // attitude.x (pitch) → 수직 이동 (Y)
+            let deltaX = CGFloat(gyro.attitude.y * gyro.sensitivity)
+            let deltaY = CGFloat(gyro.attitude.x * gyro.sensitivity)
+            InputSimulator.shared.moveMouse(deltaX: deltaX, deltaY: deltaY)
+
         case .keyEvent(let keyEvent, _):
             InputSimulator.shared.keyEvent(
                 keyCode: keyEvent.keyCode,


### PR DESCRIPTION
## Summary
- iPhone을 허공에 움직여 Mac 커서를 제어하는 레이저 포인터 기능 구현
- CoreMotion 자이로스코프 데이터를 UDP로 전송 (~60Hz)
- 캘리브레이션 및 감도 조절 UI 포함

## Changes
### iOS App
- `MotionManager.swift`: CoreMotion 래퍼 (자이로스코프 데이터 수집)
- `LaserPointerFeature.swift`: TCA reducer (시작/중지, 캘리브레이션, 감도)
- `LaserPointerView.swift`: 레이저 포인터 UI
- `TrackpadFeature/View`: LaserPointer 통합 (모드 전환 시 자동 시작/중지)
- `ConnectionClient/SnapClient`: sendGyroData 추가

### macOS MacReceiver
- `MacReceiverApp.swift`: gyroData 패킷 처리 (attitude → 커서 이동)

## Test plan
- [ ] 트랙패드 뷰에서 Laser 모드로 전환
- [ ] 레이저 버튼 탭하여 자이로 활성화
- [ ] iPhone을 움직여 Mac 커서 이동 확인
- [ ] 감도 슬라이더 조절 확인
- [ ] 기준점 재설정 버튼 동작 확인

Close #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)