### PR TITLE
[Feat]: Now Playing 정보 iOS UI 표시

### DIFF
--- a/Projects/App/Sources/Features/App/AppFeature.swift
+++ b/Projects/App/Sources/Features/App/AppFeature.swift
@@ -126,6 +126,9 @@ public struct AppFeature {
             case .connection(.appListReceived(let apps)):
                 return .send(.productivity(.appListReceived(apps)))
 
+            case .connection(.nowPlayingInfoReceived(let info)):
+                return .send(.media(.nowPlayingInfoReceived(info)))
+
             case .connection:
                 return .none
 

--- a/Projects/App/Sources/Features/Connection/ConnectionFeature.swift
+++ b/Projects/App/Sources/Features/Connection/ConnectionFeature.swift
@@ -31,6 +31,9 @@ public struct ConnectionFeature: Sendable {
         case appListReceived([AppInfo])
         case focusApp(bundleID: String, pid: UInt32)
 
+        // Now Playing
+        case nowPlayingInfoReceived(NowPlayingInfo)
+
         // Error
         case errorOccurred(ConnectionError)
         case clearError
@@ -131,6 +134,8 @@ public struct ConnectionFeature: Sendable {
                     switch packetEvent {
                     case .appList(let apps):
                         return .send(.appListReceived(apps))
+                    case .nowPlayingInfo(let info):
+                        return .send(.nowPlayingInfoReceived(info))
                     case .error(let message):
                         state.lastError = .serverError(message)
                     }
@@ -144,6 +149,10 @@ public struct ConnectionFeature: Sendable {
                 return .none
 
             case .appListReceived:
+                // Handled by parent feature
+                return .none
+
+            case .nowPlayingInfoReceived:
                 // Handled by parent feature
                 return .none
 

--- a/Projects/App/Sources/Features/Media/MediaFeature.swift
+++ b/Projects/App/Sources/Features/Media/MediaFeature.swift
@@ -5,6 +5,7 @@ import Shared
 public struct MediaFeature {
     @ObservableState
     public struct State: Equatable {
+        public var nowPlayingInfo: NowPlayingInfo = .init()
         public var isPlaying: Bool = false
         public var volume: Float = 0.5
         public var isMuted: Bool = false
@@ -26,6 +27,7 @@ public struct MediaFeature {
 
         // State Updates
         case setIsPlaying(Bool)
+        case nowPlayingInfoReceived(NowPlayingInfo)
     }
 
     @Dependency(\.connectionClient) var connectionClient
@@ -85,6 +87,11 @@ public struct MediaFeature {
 
             case .setIsPlaying(let isPlaying):
                 state.isPlaying = isPlaying
+                return .none
+
+            case .nowPlayingInfoReceived(let info):
+                state.nowPlayingInfo = info
+                state.isPlaying = info.isPlaying
                 return .none
             }
         }

--- a/Projects/App/Sources/Features/Media/MediaView.swift
+++ b/Projects/App/Sources/Features/Media/MediaView.swift
@@ -33,26 +33,111 @@ public struct MediaView: View {
 
     private var nowPlayingArea: some View {
         VStack(spacing: 16) {
-            // Album Art Placeholder
-            RoundedRectangle(cornerRadius: 16)
-                .fill(Color(.secondarySystemBackground))
-                .frame(width: 200, height: 200)
-                .overlay(
-                    Image(systemName: "music.note")
-                        .font(.system(size: 60))
-                        .foregroundStyle(Color(.tertiaryLabel))
-                )
+            // Album Art
+            albumArtView
                 .accessibilityLabel("앨범 아트")
 
+            // Track Info
+            trackInfoView
+        }
+        .animation(.easeInOut(duration: 0.3), value: store.nowPlayingInfo)
+    }
+
+    @ViewBuilder
+    private var albumArtView: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 16)
+                .fill(Color(.secondarySystemBackground))
+
+            if let artworkData = store.nowPlayingInfo.artworkData,
+               let uiImage = UIImage(data: artworkData) {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+            } else {
+                Image(systemName: appIcon)
+                    .font(.system(size: 60))
+                    .foregroundStyle(appIconColor)
+            }
+        }
+        .frame(width: 200, height: 200)
+        .shadow(color: .black.opacity(0.1), radius: 10, y: 5)
+    }
+
+    private var appIcon: String {
+        switch store.nowPlayingInfo.appName.lowercased() {
+        case "music":
+            return "music.note"
+        case "spotify":
+            return "waveform"
+        default:
+            return store.nowPlayingInfo.isEmpty ? "music.note" : "play.circle"
+        }
+    }
+
+    private var appIconColor: Color {
+        switch store.nowPlayingInfo.appName.lowercased() {
+        case "music":
+            return .pink
+        case "spotify":
+            return .green
+        default:
+            return Color(.tertiaryLabel)
+        }
+    }
+
+    @ViewBuilder
+    private var trackInfoView: some View {
+        if store.nowPlayingInfo.isEmpty {
+            // Not Playing
             VStack(spacing: 8) {
                 Text("Not Playing")
                     .font(.title3.weight(.semibold))
                     .foregroundStyle(Color(.label))
 
-                Text("Select a track to play")
+                Text("Play music on your Mac")
                     .font(.subheadline)
                     .foregroundStyle(Color(.secondaryLabel))
             }
+        } else {
+            // Now Playing Info
+            VStack(spacing: 6) {
+                // App Badge
+                HStack(spacing: 4) {
+                    Circle()
+                        .fill(store.isPlaying ? .green : .orange)
+                        .frame(width: 6, height: 6)
+
+                    Text(store.nowPlayingInfo.appName)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(Color(.secondaryLabel))
+                }
+
+                // Track Title
+                Text(store.nowPlayingInfo.title)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(Color(.label))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                // Artist
+                Text(store.nowPlayingInfo.artist)
+                    .font(.subheadline)
+                    .foregroundStyle(Color(.secondaryLabel))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                // Album (if available)
+                if !store.nowPlayingInfo.album.isEmpty {
+                    Text(store.nowPlayingInfo.album)
+                        .font(.caption)
+                        .foregroundStyle(Color(.tertiaryLabel))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+            }
+            .frame(maxWidth: 240)
         }
     }
 

--- a/Projects/App/Sources/Services/ConnectionClient.swift
+++ b/Projects/App/Sources/Services/ConnectionClient.swift
@@ -58,6 +58,7 @@ public enum ConnectionEvent: Equatable, Sendable {
 
 public enum PacketEvent: Equatable, Sendable {
     case appList([AppInfo])
+    case nowPlayingInfo(NowPlayingInfo)
     case error(String)
 }
 
@@ -260,6 +261,8 @@ private actor ConnectionActor: SnapClientDelegate, BonjourBrowserDelegate {
         switch packet {
         case .appListResponse(let response, _):
             connectionContinuation?.yield(.packet(.appList(response.apps)))
+        case .nowPlayingInfo(let info, _):
+            connectionContinuation?.yield(.packet(.nowPlayingInfo(info)))
         case .error(let snapError, _):
             connectionContinuation?.yield(.packet(.error(snapError.message)))
         default:

--- a/Projects/MacReceiver/Sources/MacReceiverApp.swift
+++ b/Projects/MacReceiver/Sources/MacReceiverApp.swift
@@ -345,6 +345,8 @@ final class ServerManager: ObservableObject {
     @Published var receivedPackets: [String] = []
 
     private var server: SnapServer?
+    private var nowPlayingTimer: Timer?
+    private var lastNowPlayingInfo: NowPlayingInfo?
 
     init() {
         startServer()
@@ -378,6 +380,39 @@ final class ServerManager: ObservableObject {
 
     func disconnectClient() {
         server?.disconnectClient()
+    }
+
+    // MARK: - Now Playing
+
+    private func startNowPlayingUpdates() {
+        stopNowPlayingUpdates()
+
+        // 즉시 한 번 전송
+        sendNowPlayingInfoIfChanged()
+
+        // 2초마다 업데이트 전송
+        nowPlayingTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.sendNowPlayingInfoIfChanged()
+            }
+        }
+    }
+
+    private func stopNowPlayingUpdates() {
+        nowPlayingTimer?.invalidate()
+        nowPlayingTimer = nil
+        lastNowPlayingInfo = nil
+    }
+
+    private func sendNowPlayingInfoIfChanged() {
+        let currentInfo = MediaController.shared.getNowPlayingInfo()
+
+        // 정보가 변경되었을 때만 전송
+        if currentInfo != lastNowPlayingInfo {
+            lastNowPlayingInfo = currentInfo
+            server?.sendNowPlayingInfo(currentInfo)
+            logPacket("NowPlaying: \(currentInfo.isEmpty ? "No media" : "\(currentInfo.title) - \(currentInfo.artist)")")
+        }
     }
 
     private func handlePacket(_ packet: DecodedPacket) {
@@ -497,6 +532,7 @@ extension ServerManager: SnapServerDelegate {
         Task { @MainActor in
             self.connectedDevice = deviceName
             self.logPacket("Connected: \(deviceName)")
+            self.startNowPlayingUpdates()
         }
     }
 
@@ -504,6 +540,7 @@ extension ServerManager: SnapServerDelegate {
         Task { @MainActor in
             self.connectedDevice = nil
             self.logPacket("Disconnected: \(deviceName)")
+            self.stopNowPlayingUpdates()
         }
     }
 

--- a/Projects/MacReceiver/Sources/Server/MediaController.swift
+++ b/Projects/MacReceiver/Sources/Server/MediaController.swift
@@ -122,28 +122,69 @@ public final class MediaController {
 
     // MARK: - Now Playing Info
 
-    /// 현재 재생 중인 앱 정보
-    public struct NowPlayingInfo: Sendable {
-        public let appName: String
-        public let title: String
-        public let artist: String
-        public let album: String
-        public let isPlaying: Bool
+    /// 현재 재생 정보 가져오기
+    public func getNowPlayingInfo() -> NowPlayingInfo {
+        // Music 앱 체크
+        if let info = getMusicAppInfo() {
+            return info
+        }
+
+        // Spotify 체크
+        if let info = getSpotifyInfo() {
+            return info
+        }
+
+        // 재생 중인 앱 없음
+        return NowPlayingInfo()
     }
 
-    /// 현재 재생 정보 가져오기
-    public func getNowPlayingInfo() -> NowPlayingInfo? {
+    private func getMusicAppInfo() -> NowPlayingInfo? {
         let script = """
             tell application "System Events"
-                set frontApp to name of first application process whose frontmost is true
+                if not (exists process "Music") then return ""
             end tell
 
             tell application "Music"
-                if player state is playing then
+                if player state is playing or player state is paused then
                     set trackName to name of current track
                     set trackArtist to artist of current track
                     set trackAlbum to album of current track
-                    return "Music|" & trackName & "|" & trackArtist & "|" & trackAlbum & "|true"
+                    set isPlaying to (player state is playing)
+                    return "Music|" & trackName & "|" & trackArtist & "|" & trackAlbum & "|" & isPlaying
+                else
+                    return ""
+                end if
+            end tell
+        """
+
+        if let result = runAppleScript(script), !result.isEmpty {
+            let parts = result.components(separatedBy: "|")
+            if parts.count >= 5 {
+                return NowPlayingInfo(
+                    appName: parts[0],
+                    title: parts[1],
+                    artist: parts[2],
+                    album: parts[3],
+                    isPlaying: parts[4] == "true"
+                )
+            }
+        }
+        return nil
+    }
+
+    private func getSpotifyInfo() -> NowPlayingInfo? {
+        let script = """
+            tell application "System Events"
+                if not (exists process "Spotify") then return ""
+            end tell
+
+            tell application "Spotify"
+                if player state is playing or player state is paused then
+                    set trackName to name of current track
+                    set trackArtist to artist of current track
+                    set trackAlbum to album of current track
+                    set isPlaying to (player state is playing)
+                    return "Spotify|" & trackName & "|" & trackArtist & "|" & trackAlbum & "|" & isPlaying
                 else
                     return ""
                 end if

--- a/Projects/MacReceiver/Sources/Server/SnapServer.swift
+++ b/Projects/MacReceiver/Sources/Server/SnapServer.swift
@@ -118,6 +118,12 @@ public final class SnapServer: @unchecked Sendable {
         client.send(response, type: .appListResponse)
     }
 
+    /// Now Playing 정보 전송
+    public func sendNowPlayingInfo(_ info: NowPlayingInfo) {
+        guard let client = connectedClient else { return }
+        client.send(info, type: .nowPlayingInfo)
+    }
+
     // MARK: - Private Methods
 
     private static func getDeviceID() -> String {

--- a/Projects/Shared/Sources/Network/MessageType.swift
+++ b/Projects/Shared/Sources/Network/MessageType.swift
@@ -21,6 +21,8 @@ public enum MessageType: UInt8, Sendable {
     case keyCombo = 0x21
     /// 미디어 제어
     case mediaControl = 0x30
+    /// Now Playing 정보 (macOS → iOS)
+    case nowPlayingInfo = 0x31
     /// 윈도우 스냅
     case windowSnap = 0x40
     /// 앱 목록 요청

--- a/Projects/Shared/Sources/Network/PacketDecoder.swift
+++ b/Projects/Shared/Sources/Network/PacketDecoder.swift
@@ -22,6 +22,7 @@ public enum DecodedPacket: Sendable {
     case keyEvent(KeyEvent, header: PacketHeader)
     case keyCombo(KeyCombo, header: PacketHeader)
     case mediaControl(MediaControl, header: PacketHeader)
+    case nowPlayingInfo(NowPlayingInfo, header: PacketHeader)
     case windowSnap(WindowSnap, header: PacketHeader)
     case appListRequest(AppListRequest, header: PacketHeader)
     case appListResponse(AppListResponse, header: PacketHeader)
@@ -47,6 +48,7 @@ public enum DecodedPacket: Sendable {
         case .keyEvent: return .keyEvent
         case .keyCombo: return .keyCombo
         case .mediaControl: return .mediaControl
+        case .nowPlayingInfo: return .nowPlayingInfo
         case .windowSnap: return .windowSnap
         case .appListRequest: return .appListRequest
         case .appListResponse: return .appListResponse
@@ -72,6 +74,7 @@ public enum DecodedPacket: Sendable {
              .keyEvent(_, let header),
              .keyCombo(_, let header),
              .mediaControl(_, let header),
+             .nowPlayingInfo(_, let header),
              .windowSnap(_, let header),
              .appListRequest(_, let header),
              .appListResponse(_, let header),
@@ -137,6 +140,9 @@ public enum PacketDecoder {
             case .mediaControl:
                 let message = try decoder.decode(MediaControl.self, from: payload)
                 return .mediaControl(message, header: header)
+            case .nowPlayingInfo:
+                let message = try decoder.decode(NowPlayingInfo.self, from: payload)
+                return .nowPlayingInfo(message, header: header)
             case .windowSnap:
                 let message = try decoder.decode(WindowSnap.self, from: payload)
                 return .windowSnap(message, header: header)

--- a/Projects/Shared/Sources/Protocol/ControlMessages.swift
+++ b/Projects/Shared/Sources/Protocol/ControlMessages.swift
@@ -97,3 +97,42 @@ public struct SiriCommand: Codable, Sendable, Equatable {
         self.text = text
     }
 }
+
+// MARK: - NowPlayingInfo
+
+/// 현재 재생 중인 미디어 정보 (macOS → iOS)
+public struct NowPlayingInfo: Codable, Sendable, Equatable {
+    /// 재생 중인 앱 이름 (Music, Spotify 등)
+    public var appName: String
+    /// 트랙 제목
+    public var title: String
+    /// 아티스트명
+    public var artist: String
+    /// 앨범명
+    public var album: String
+    /// 재생 상태
+    public var isPlaying: Bool
+    /// 앨범 아트 (JPEG/PNG 데이터, Base64 인코딩)
+    public var artworkData: Data?
+
+    public init(
+        appName: String = "",
+        title: String = "",
+        artist: String = "",
+        album: String = "",
+        isPlaying: Bool = false,
+        artworkData: Data? = nil
+    ) {
+        self.appName = appName
+        self.title = title
+        self.artist = artist
+        self.album = album
+        self.isPlaying = isPlaying
+        self.artworkData = artworkData
+    }
+
+    /// 재생 정보가 비어있는지 확인
+    public var isEmpty: Bool {
+        title.isEmpty && artist.isEmpty
+    }
+}


### PR DESCRIPTION
## Summary

- macOS에서 현재 재생 중인 미디어 정보를 iOS 앱에 실시간으로 표시
- Music 및 Spotify 앱 지원
- 트랙 제목, 아티스트, 앨범명, 재생 상태 표시

## Changes

### Shared
- `NowPlayingInfo` 메시지 정의 (appName, title, artist, album, isPlaying, artworkData)
- `MessageType.nowPlayingInfo = 0x31` 추가
- `PacketDecoder`에 NowPlayingInfo 디코딩 지원

### macOS (MacReceiver)
- `MediaController`: Music/Spotify 앱에서 재생 정보 조회
- `SnapServer`: `sendNowPlayingInfo()` 메서드 추가
- 클라이언트 연결 시 2초 간격으로 Now Playing 정보 전송

### iOS (App)
- `ConnectionClient`: `.nowPlayingInfo` 패킷 이벤트 처리
- `MediaFeature`: `nowPlayingInfo` state 및 액션 추가
- `MediaView`: 트랙 정보 UI 구현
  - 앱별 아이콘/색상 구분 (Music: 핑크, Spotify: 그린)
  - 재생 상태 표시 (녹색: 재생 중, 주황: 일시정지)

## Test Plan

- [ ] macOS에서 Music 앱으로 음악 재생 시 iOS에 정보 표시 확인
- [ ] macOS에서 Spotify 앱으로 음악 재생 시 iOS에 정보 표시 확인
- [ ] 트랙 변경 시 iOS UI 업데이트 확인
- [ ] 재생/일시정지 상태 동기화 확인
- [ ] 연결 해제 후 재연결 시 정상 동작 확인

Close #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)