### PR TITLE
[Feat]: 숏폼 비디오 리모컨 구현 - YouTube/Instagram/TikTok (#69)

### DIFF
--- a/Projects/App/Sources/Features/Productivity/ProductivityFeature.swift
+++ b/Projects/App/Sources/Features/Productivity/ProductivityFeature.swift
@@ -11,6 +11,7 @@ public struct ProductivityFeature {
         public var macro: MacroFeature.State = .init()
         public var voiceTyping: VoiceTypingFeature.State = .init()
         public var presenter: PresenterFeature.State = .init()
+        public var shortsRemote: ShortsRemoteFeature.State = .init()
     }
 
     public enum Action: Equatable, Sendable {
@@ -36,6 +37,9 @@ public struct ProductivityFeature {
 
         // Presenter
         case presenter(PresenterFeature.Action)
+
+        // Shorts Remote
+        case shortsRemote(ShortsRemoteFeature.Action)
     }
 
     @Dependency(\.connectionClient) var connectionClient
@@ -53,6 +57,10 @@ public struct ProductivityFeature {
 
         Scope(state: \.presenter, action: \.presenter) {
             PresenterFeature()
+        }
+
+        Scope(state: \.shortsRemote, action: \.shortsRemote) {
+            ShortsRemoteFeature()
         }
 
         Reduce { state, action in
@@ -114,6 +122,9 @@ public struct ProductivityFeature {
                 return .none
 
             case .presenter:
+                return .none
+
+            case .shortsRemote:
                 return .none
             }
         }

--- a/Projects/App/Sources/Features/Productivity/ProductivityView.swift
+++ b/Projects/App/Sources/Features/Productivity/ProductivityView.swift
@@ -12,6 +12,9 @@ public struct ProductivityView: View {
     public var body: some View {
         ScrollView {
             VStack(spacing: 24) {
+                // Shorts Remote Section
+                shortsRemoteSection
+
                 // Presenter Section
                 presenterSection
 
@@ -34,6 +37,15 @@ public struct ProductivityView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color(.systemBackground))
+    }
+
+    // MARK: - Shorts Remote Section
+
+    @ViewBuilder
+    private var shortsRemoteSection: some View {
+        ShortsRemoteSection(
+            store: store.scope(state: \.shortsRemote, action: \.shortsRemote)
+        )
     }
 
     // MARK: - Presenter Section

--- a/Projects/App/Sources/Features/ShortsRemote/ShortsRemoteFeature.swift
+++ b/Projects/App/Sources/Features/ShortsRemote/ShortsRemoteFeature.swift
@@ -1,0 +1,129 @@
+import ComposableArchitecture
+import Foundation
+
+@Reducer
+public struct ShortsRemoteFeature {
+    // MARK: - Platform
+
+    public enum Platform: String, CaseIterable, Sendable {
+        case youtube = "YouTube"
+        case instagram = "Instagram"
+        case tiktok = "TikTok"
+
+        var icon: String {
+            switch self {
+            case .youtube: return "play.rectangle.fill"
+            case .instagram: return "camera.circle.fill"
+            case .tiktok: return "music.note"
+            }
+        }
+    }
+
+    // MARK: - State
+
+    @ObservableState
+    public struct State: Equatable {
+        public var selectedPlatform: Platform = .youtube
+        public var isMuted: Bool = false
+        public var isPaused: Bool = false
+
+        public init() {}
+    }
+
+    // MARK: - Action
+
+    public enum Action: Equatable, Sendable {
+        // Platform
+        case platformSelected(Platform)
+
+        // Navigation
+        case nextVideo
+        case previousVideo
+
+        // Playback
+        case togglePlayPause
+        case toggleMute
+        case seekForward
+        case seekBackward
+
+        // Haptic
+        case triggerHaptic
+    }
+
+    // MARK: - Dependencies
+
+    @Dependency(\.connectionClient) var connectionClient
+
+    public init() {}
+
+    // MARK: - Key Codes
+
+    private enum KeyCode {
+        static let upArrow: UInt32 = 126
+        static let downArrow: UInt32 = 125
+        static let leftArrow: UInt32 = 123
+        static let rightArrow: UInt32 = 124
+        static let space: UInt32 = 49
+        static let mKey: UInt32 = 46
+        static let kKey: UInt32 = 40  // YouTube prev
+        static let jKey: UInt32 = 38  // YouTube next
+    }
+
+    // MARK: - Body
+
+    public var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .platformSelected(let platform):
+                state.selectedPlatform = platform
+                return .none
+
+            case .nextVideo:
+                // All platforms use down arrow for next video in fullscreen/shorts mode
+                return .run { [connectionClient] send in
+                    await connectionClient.sendKeyEvent(KeyCode.downArrow, .press, 0)
+                    await send(.triggerHaptic)
+                }
+
+            case .previousVideo:
+                // All platforms use up arrow for previous video
+                return .run { [connectionClient] send in
+                    await connectionClient.sendKeyEvent(KeyCode.upArrow, .press, 0)
+                    await send(.triggerHaptic)
+                }
+
+            case .togglePlayPause:
+                state.isPaused.toggle()
+                return .run { [connectionClient] send in
+                    // Space to toggle play/pause
+                    await connectionClient.sendKeyEvent(KeyCode.space, .press, 0)
+                    await send(.triggerHaptic)
+                }
+
+            case .toggleMute:
+                state.isMuted.toggle()
+                return .run { [connectionClient] send in
+                    // M key to toggle mute
+                    await connectionClient.sendKeyEvent(KeyCode.mKey, .press, 0)
+                    await send(.triggerHaptic)
+                }
+
+            case .seekForward:
+                return .run { [connectionClient] send in
+                    await connectionClient.sendKeyEvent(KeyCode.rightArrow, .press, 0)
+                    await send(.triggerHaptic)
+                }
+
+            case .seekBackward:
+                return .run { [connectionClient] send in
+                    await connectionClient.sendKeyEvent(KeyCode.leftArrow, .press, 0)
+                    await send(.triggerHaptic)
+                }
+
+            case .triggerHaptic:
+                // Haptic feedback is handled in the View
+                return .none
+            }
+        }
+    }
+}

--- a/Projects/App/Sources/Features/ShortsRemote/ShortsRemoteView.swift
+++ b/Projects/App/Sources/Features/ShortsRemote/ShortsRemoteView.swift
@@ -1,0 +1,509 @@
+import ComposableArchitecture
+import SwiftUI
+import UIKit
+
+public struct ShortsRemoteView: View {
+    @Bindable var store: StoreOf<ShortsRemoteFeature>
+
+    public init(store: StoreOf<ShortsRemoteFeature>) {
+        self.store = store
+    }
+
+    public var body: some View {
+        VStack(spacing: 20) {
+            // Platform Picker
+            platformPicker
+
+            // Swipe Navigation Area
+            swipeArea
+
+            // Control Buttons
+            controlButtons
+        }
+        .padding()
+        .background(Color(.systemBackground))
+    }
+
+    // MARK: - Platform Picker
+
+    private var platformPicker: some View {
+        HStack(spacing: 12) {
+            ForEach(ShortsRemoteFeature.Platform.allCases, id: \.self) { platform in
+                PlatformButton(
+                    platform: platform,
+                    isSelected: store.selectedPlatform == platform
+                ) {
+                    store.send(.platformSelected(platform))
+                }
+            }
+        }
+    }
+
+    // MARK: - Swipe Area
+
+    private var swipeArea: some View {
+        SwipeNavigationArea(
+            onSwipeUp: { store.send(.nextVideo) },
+            onSwipeDown: { store.send(.previousVideo) }
+        )
+    }
+
+    // MARK: - Control Buttons
+
+    private var controlButtons: some View {
+        HStack(spacing: 20) {
+            // Seek Backward
+            ShortsControlButton(
+                icon: "gobackward.5",
+                label: "-5s"
+            ) {
+                store.send(.seekBackward)
+            }
+
+            // Play/Pause
+            ShortsControlButton(
+                icon: store.isPaused ? "play.fill" : "pause.fill",
+                label: store.isPaused ? "재생" : "일시정지",
+                isLarge: true
+            ) {
+                store.send(.togglePlayPause)
+            }
+
+            // Seek Forward
+            ShortsControlButton(
+                icon: "goforward.5",
+                label: "+5s"
+            ) {
+                store.send(.seekForward)
+            }
+
+            // Mute
+            ShortsControlButton(
+                icon: store.isMuted ? "speaker.slash.fill" : "speaker.wave.2.fill",
+                label: store.isMuted ? "음소거 해제" : "음소거"
+            ) {
+                store.send(.toggleMute)
+            }
+        }
+    }
+}
+
+// MARK: - Platform Button
+
+struct PlatformButton: View {
+    let platform: ShortsRemoteFeature.Platform
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 4) {
+                Image(systemName: platform.icon)
+                    .font(.system(size: 24))
+
+                Text(platform.rawValue)
+                    .font(.caption)
+                    .fontWeight(.medium)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(isSelected ? platformColor.opacity(0.15) : Color(.tertiarySystemBackground))
+            )
+            .foregroundStyle(isSelected ? platformColor : .secondary)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(isSelected ? platformColor.opacity(0.5) : Color.clear, lineWidth: 2)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var platformColor: Color {
+        switch platform {
+        case .youtube: return .red
+        case .instagram: return .pink
+        case .tiktok: return .primary
+        }
+    }
+}
+
+// MARK: - Swipe Navigation Area
+
+struct SwipeNavigationArea: View {
+    let onSwipeUp: () -> Void
+    let onSwipeDown: () -> Void
+
+    @State private var offset: CGFloat = 0
+    @State private var showUpIndicator = false
+    @State private var showDownIndicator = false
+
+    private let threshold: CGFloat = 50
+
+    var body: some View {
+        GeometryReader { _ in
+            ZStack {
+                // Background
+                RoundedRectangle(cornerRadius: 24)
+                    .fill(Color(.secondarySystemBackground))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 24)
+                            .strokeBorder(Color(.separator), lineWidth: 1)
+                    )
+
+                // Content
+                VStack(spacing: 20) {
+                    // Up indicator
+                    VStack(spacing: 8) {
+                        Image(systemName: "chevron.up")
+                            .font(.system(size: 28, weight: .semibold))
+                            .foregroundStyle(showDownIndicator ? .primary : .tertiary)
+
+                        Text("이전 영상")
+                            .font(.caption)
+                            .foregroundStyle(showDownIndicator ? .primary : .tertiary)
+                    }
+                    .opacity(showDownIndicator ? 1 : 0.5)
+
+                    Spacer()
+
+                    // Center instructions
+                    VStack(spacing: 12) {
+                        Image(systemName: "hand.draw.fill")
+                            .font(.system(size: 48))
+                            .foregroundStyle(.secondary)
+
+                        Text("위아래로 스와이프")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    .offset(y: offset * 0.3)
+
+                    Spacer()
+
+                    // Down indicator
+                    VStack(spacing: 8) {
+                        Text("다음 영상")
+                            .font(.caption)
+                            .foregroundStyle(showUpIndicator ? .primary : .tertiary)
+
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: 28, weight: .semibold))
+                            .foregroundStyle(showUpIndicator ? .primary : .tertiary)
+                    }
+                    .opacity(showUpIndicator ? 1 : 0.5)
+                }
+                .padding(.vertical, 30)
+            }
+            .gesture(
+                DragGesture()
+                    .onChanged { value in
+                        offset = value.translation.height
+                        withAnimation(.easeOut(duration: 0.1)) {
+                            showUpIndicator = offset < -threshold
+                            showDownIndicator = offset > threshold
+                        }
+                    }
+                    .onEnded { value in
+                        let velocity = value.predictedEndTranslation.height - value.translation.height
+
+                        if offset < -threshold || velocity < -100 {
+                            // Swipe up -> next video
+                            triggerHaptic()
+                            onSwipeUp()
+                        } else if offset > threshold || velocity > 100 {
+                            // Swipe down -> previous video
+                            triggerHaptic()
+                            onSwipeDown()
+                        }
+
+                        withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                            offset = 0
+                            showUpIndicator = false
+                            showDownIndicator = false
+                        }
+                    }
+            )
+        }
+        .frame(height: 280)
+    }
+
+    private func triggerHaptic() {
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+    }
+}
+
+// MARK: - Shorts Control Button
+
+struct ShortsControlButton: View {
+    let icon: String
+    let label: String
+    var isLarge: Bool = false
+    let action: () -> Void
+
+    var body: some View {
+        Button {
+            triggerHaptic()
+            action()
+        } label: {
+            VStack(spacing: 6) {
+                Image(systemName: icon)
+                    .font(.system(size: isLarge ? 28 : 22))
+
+                Text(label)
+                    .font(.caption2)
+            }
+            .frame(width: isLarge ? 80 : 60, height: isLarge ? 80 : 60)
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(Color(.tertiarySystemBackground))
+            )
+            .foregroundStyle(.primary)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func triggerHaptic() {
+        let generator = UIImpactFeedbackGenerator(style: .light)
+        generator.impactOccurred()
+    }
+}
+
+// MARK: - Shorts Remote Section (for embedding in ProductivityView)
+
+public struct ShortsRemoteSection: View {
+    @Bindable var store: StoreOf<ShortsRemoteFeature>
+
+    public init(store: StoreOf<ShortsRemoteFeature>) {
+        self.store = store
+    }
+
+    public var body: some View {
+        VStack(spacing: 16) {
+            // Header
+            HStack {
+                Image(systemName: "play.rectangle.fill")
+                    .foregroundStyle(.red)
+                Text("숏폼 리모컨")
+                    .font(.headline)
+                Spacer()
+            }
+
+            // Platform Picker
+            HStack(spacing: 8) {
+                ForEach(ShortsRemoteFeature.Platform.allCases, id: \.self) { platform in
+                    PlatformChip(
+                        platform: platform,
+                        isSelected: store.selectedPlatform == platform
+                    ) {
+                        store.send(.platformSelected(platform))
+                    }
+                }
+            }
+
+            // Compact Swipe Area
+            CompactSwipeArea(
+                onSwipeUp: { store.send(.nextVideo) },
+                onSwipeDown: { store.send(.previousVideo) }
+            )
+
+            // Compact Controls
+            HStack(spacing: 12) {
+                CompactControlButton(icon: "gobackward.5") {
+                    store.send(.seekBackward)
+                }
+
+                CompactControlButton(
+                    icon: store.isPaused ? "play.fill" : "pause.fill",
+                    isHighlighted: true
+                ) {
+                    store.send(.togglePlayPause)
+                }
+
+                CompactControlButton(icon: "goforward.5") {
+                    store.send(.seekForward)
+                }
+
+                Spacer()
+
+                CompactControlButton(
+                    icon: store.isMuted ? "speaker.slash.fill" : "speaker.wave.2.fill"
+                ) {
+                    store.send(.toggleMute)
+                }
+            }
+        }
+        .padding()
+        .background(Color(.secondarySystemBackground).opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+}
+
+// MARK: - Platform Chip
+
+struct PlatformChip: View {
+    let platform: ShortsRemoteFeature.Platform
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Image(systemName: platform.icon)
+                    .font(.system(size: 14))
+
+                Text(platform.rawValue)
+                    .font(.caption)
+                    .fontWeight(.medium)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(
+                Capsule()
+                    .fill(isSelected ? platformColor.opacity(0.15) : Color(.tertiarySystemBackground))
+            )
+            .foregroundStyle(isSelected ? platformColor : .secondary)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var platformColor: Color {
+        switch platform {
+        case .youtube: return .red
+        case .instagram: return .pink
+        case .tiktok: return .primary
+        }
+    }
+}
+
+// MARK: - Compact Swipe Area
+
+struct CompactSwipeArea: View {
+    let onSwipeUp: () -> Void
+    let onSwipeDown: () -> Void
+
+    @State private var offset: CGFloat = 0
+
+    private let threshold: CGFloat = 30
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 16)
+                .fill(Color(.tertiarySystemBackground))
+
+            HStack {
+                // Up/Previous
+                VStack(spacing: 4) {
+                    Image(systemName: "chevron.up")
+                        .font(.system(size: 20, weight: .semibold))
+                    Text("이전")
+                        .font(.caption2)
+                }
+                .frame(maxWidth: .infinity)
+                .foregroundStyle(offset > threshold ? .primary : .tertiary)
+
+                Divider()
+                    .frame(height: 40)
+
+                // Center
+                VStack(spacing: 4) {
+                    Image(systemName: "hand.draw")
+                        .font(.system(size: 24))
+                    Text("스와이프")
+                        .font(.caption2)
+                }
+                .frame(maxWidth: .infinity)
+                .foregroundStyle(.secondary)
+
+                Divider()
+                    .frame(height: 40)
+
+                // Down/Next
+                VStack(spacing: 4) {
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 20, weight: .semibold))
+                    Text("다음")
+                        .font(.caption2)
+                }
+                .frame(maxWidth: .infinity)
+                .foregroundStyle(offset < -threshold ? .primary : .tertiary)
+            }
+            .padding(.vertical, 12)
+        }
+        .frame(height: 80)
+        .gesture(
+            DragGesture()
+                .onChanged { value in
+                    offset = value.translation.height
+                }
+                .onEnded { _ in
+                    if offset < -threshold {
+                        triggerHaptic()
+                        onSwipeUp()
+                    } else if offset > threshold {
+                        triggerHaptic()
+                        onSwipeDown()
+                    }
+                    withAnimation(.spring(response: 0.3)) {
+                        offset = 0
+                    }
+                }
+        )
+    }
+
+    private func triggerHaptic() {
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+    }
+}
+
+// MARK: - Compact Control Button
+
+struct CompactControlButton: View {
+    let icon: String
+    var isHighlighted: Bool = false
+    let action: () -> Void
+
+    var body: some View {
+        Button {
+            triggerHaptic()
+            action()
+        } label: {
+            Image(systemName: icon)
+                .font(.system(size: 20))
+                .frame(width: 48, height: 48)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(isHighlighted ? Color.accentColor.opacity(0.15) : Color(.tertiarySystemBackground))
+                )
+                .foregroundStyle(isHighlighted ? Color.accentColor : .primary)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func triggerHaptic() {
+        let generator = UIImpactFeedbackGenerator(style: .light)
+        generator.impactOccurred()
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    ShortsRemoteView(
+        store: Store(initialState: ShortsRemoteFeature.State()) {
+            ShortsRemoteFeature()
+        }
+    )
+}
+
+#Preview("Section") {
+    ShortsRemoteSection(
+        store: Store(initialState: ShortsRemoteFeature.State()) {
+            ShortsRemoteFeature()
+        }
+    )
+    .padding()
+}


### PR DESCRIPTION
## Summary
- 숏폼 비디오(YouTube Shorts, Instagram Reels, TikTok) 리모컨 기능 구현
- 스와이프 제스처로 다음/이전 영상 탐색
- 플랫폼 선택 및 재생 컨트롤 버튼 제공

## Changes
- `ShortsRemoteFeature.swift`: TCA Reducer with keyboard shortcut mapping
  - Platform selection (YouTube/Instagram/TikTok)
  - Navigation: up/down arrows for next/prev video
  - Playback: Space (play/pause), M (mute), left/right arrows (seek)
- `ShortsRemoteView.swift`: SwiftUI UI with swipe gestures
  - `SwipeNavigationArea`: Full-height swipe area with visual indicators
  - `ShortsControlButton`: Playback control buttons
  - `ShortsRemoteSection`: Compact section for ProductivityView
- `ProductivityFeature.swift`: Integration with shortsRemote state
- `ProductivityView.swift`: Added shortsRemoteSection at the top

## Test plan
- [ ] 플랫폼 선택 버튼 동작 확인
- [ ] 스와이프 제스처로 다음/이전 영상 탐색 확인 (키보드 up/down 전송)
- [ ] 재생/일시정지 버튼 동작 확인 (Space 키 전송)
- [ ] 음소거 버튼 동작 확인 (M 키 전송)
- [ ] 5초 탐색 버튼 동작 확인 (left/right 화살표 전송)
- [ ] 햅틱 피드백 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)