### PR TITLE
[Feat]: 퀵 런치 - URL/앱 바로가기 (#71)

### DIFF
--- a/Projects/App/Sources/Features/Productivity/ProductivityFeature.swift
+++ b/Projects/App/Sources/Features/Productivity/ProductivityFeature.swift
@@ -12,6 +12,7 @@ public struct ProductivityFeature {
         public var voiceTyping: VoiceTypingFeature.State = .init()
         public var presenter: PresenterFeature.State = .init()
         public var shortsRemote: ShortsRemoteFeature.State = .init()
+        public var quickLaunch: QuickLaunchFeature.State = .init()
     }
 
     public enum Action: Equatable, Sendable {
@@ -40,6 +41,9 @@ public struct ProductivityFeature {
 
         // Shorts Remote
         case shortsRemote(ShortsRemoteFeature.Action)
+
+        // Quick Launch
+        case quickLaunch(QuickLaunchFeature.Action)
     }
 
     @Dependency(\.connectionClient) var connectionClient
@@ -61,6 +65,10 @@ public struct ProductivityFeature {
 
         Scope(state: \.shortsRemote, action: \.shortsRemote) {
             ShortsRemoteFeature()
+        }
+
+        Scope(state: \.quickLaunch, action: \.quickLaunch) {
+            QuickLaunchFeature()
         }
 
         Reduce { state, action in
@@ -125,6 +133,9 @@ public struct ProductivityFeature {
                 return .none
 
             case .shortsRemote:
+                return .none
+
+            case .quickLaunch:
                 return .none
             }
         }

--- a/Projects/App/Sources/Features/Productivity/ProductivityView.swift
+++ b/Projects/App/Sources/Features/Productivity/ProductivityView.swift
@@ -12,6 +12,9 @@ public struct ProductivityView: View {
     public var body: some View {
         ScrollView {
             VStack(spacing: 24) {
+                // Quick Launch Section
+                quickLaunchSection
+
                 // Shorts Remote Section
                 shortsRemoteSection
 
@@ -37,6 +40,15 @@ public struct ProductivityView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color(.systemBackground))
+    }
+
+    // MARK: - Quick Launch Section
+
+    @ViewBuilder
+    private var quickLaunchSection: some View {
+        QuickLaunchSection(
+            store: store.scope(state: \.quickLaunch, action: \.quickLaunch)
+        )
     }
 
     // MARK: - Shorts Remote Section

--- a/Projects/App/Sources/Features/QuickLaunch/QuickLaunchFeature.swift
+++ b/Projects/App/Sources/Features/QuickLaunch/QuickLaunchFeature.swift
@@ -1,0 +1,262 @@
+import ComposableArchitecture
+import Foundation
+import SwiftUI
+
+@Reducer
+public struct QuickLaunchFeature {
+    // MARK: - Quick Launch Item
+
+    public struct QuickLaunchItem: Codable, Identifiable, Equatable, Sendable {
+        public var id: UUID
+        public var name: String
+        public var icon: String
+        public var color: QuickLaunchColor
+        public var type: ItemType
+        public var url: String
+
+        public enum ItemType: String, Codable, Sendable {
+            case url
+            case app
+        }
+
+        public init(
+            id: UUID = UUID(),
+            name: String,
+            icon: String,
+            color: QuickLaunchColor,
+            type: ItemType,
+            url: String
+        ) {
+            self.id = id
+            self.name = name
+            self.icon = icon
+            self.color = color
+            self.type = type
+            self.url = url
+        }
+
+        // Default presets
+        public static let defaults: [QuickLaunchItem] = [
+            QuickLaunchItem(
+                name: "Netflix",
+                icon: "play.tv.fill",
+                color: .red,
+                type: .url,
+                url: "https://www.netflix.com"
+            ),
+            QuickLaunchItem(
+                name: "YouTube",
+                icon: "play.rectangle.fill",
+                color: .red,
+                type: .url,
+                url: "https://www.youtube.com"
+            ),
+            QuickLaunchItem(
+                name: "Spotify",
+                icon: "music.note",
+                color: .green,
+                type: .url,
+                url: "https://open.spotify.com"
+            ),
+            QuickLaunchItem(
+                name: "GitHub",
+                icon: "chevron.left.forwardslash.chevron.right",
+                color: .gray,
+                type: .url,
+                url: "https://github.com"
+            ),
+            QuickLaunchItem(
+                name: "ChatGPT",
+                icon: "bubble.left.and.bubble.right.fill",
+                color: .teal,
+                type: .url,
+                url: "https://chat.openai.com"
+            ),
+            QuickLaunchItem(
+                name: "Twitter",
+                icon: "bubble.left.fill",
+                color: .blue,
+                type: .url,
+                url: "https://twitter.com"
+            )
+        ]
+    }
+
+    public enum QuickLaunchColor: String, Codable, CaseIterable, Sendable {
+        case red, orange, yellow, green, teal, blue, purple, pink, gray
+
+        public var color: Color {
+            switch self {
+            case .red: return .red
+            case .orange: return .orange
+            case .yellow: return .yellow
+            case .green: return .green
+            case .teal: return .teal
+            case .blue: return .blue
+            case .purple: return .purple
+            case .pink: return .pink
+            case .gray: return .gray
+            }
+        }
+    }
+
+    // MARK: - State
+
+    @ObservableState
+    public struct State: Equatable {
+        public var items: [QuickLaunchItem] = []
+        public var isEditing: Bool = false
+        public var editorState: EditorState?
+
+        public init() {
+            self.items = Self.loadItems()
+        }
+
+        // MARK: - Persistence
+
+        private static let itemsKey = "snap.quickLaunchItems"
+
+        static func loadItems() -> [QuickLaunchItem] {
+            guard let data = UserDefaults.standard.data(forKey: itemsKey),
+                  let items = try? JSONDecoder().decode([QuickLaunchItem].self, from: data) else {
+                return QuickLaunchItem.defaults
+            }
+            return items
+        }
+
+        mutating func saveItems() {
+            if let data = try? JSONEncoder().encode(items) {
+                UserDefaults.standard.set(data, forKey: Self.itemsKey)
+            }
+        }
+    }
+
+    // MARK: - Editor State
+
+    public struct EditorState: Equatable {
+        public var item: QuickLaunchItem
+        public var isNew: Bool
+
+        public init(item: QuickLaunchItem? = nil) {
+            if let item = item {
+                self.item = item
+                self.isNew = false
+            } else {
+                self.item = QuickLaunchItem(
+                    name: "",
+                    icon: "link",
+                    color: .blue,
+                    type: .url,
+                    url: ""
+                )
+                self.isNew = true
+            }
+        }
+    }
+
+    // MARK: - Action
+
+    public enum Action: Equatable, Sendable {
+        // Item actions
+        case itemTapped(QuickLaunchItem)
+        case itemDeleted(QuickLaunchItem)
+
+        // Edit mode
+        case editModeToggled
+
+        // Editor
+        case addItemTapped
+        case editItemTapped(QuickLaunchItem)
+        case dismissEditor
+        case saveItem(QuickLaunchItem)
+
+        // Editor field updates
+        case updateItemName(String)
+        case updateItemIcon(String)
+        case updateItemColor(QuickLaunchColor)
+        case updateItemType(QuickLaunchItem.ItemType)
+        case updateItemURL(String)
+
+        // Reset
+        case resetToDefaults
+    }
+
+    // MARK: - Dependencies
+
+    @Dependency(\.connectionClient) var connectionClient
+
+    public init() {}
+
+    // MARK: - Body
+
+    public var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .itemTapped(let item):
+                guard !state.isEditing else {
+                    return .send(.editItemTapped(item))
+                }
+
+                return .run { [connectionClient] _ in
+                    await connectionClient.sendOpenURL(item.url)
+                }
+
+            case .itemDeleted(let item):
+                state.items.removeAll { $0.id == item.id }
+                state.saveItems()
+                return .none
+
+            case .editModeToggled:
+                state.isEditing.toggle()
+                return .none
+
+            case .addItemTapped:
+                state.editorState = EditorState()
+                return .none
+
+            case .editItemTapped(let item):
+                state.editorState = EditorState(item: item)
+                return .none
+
+            case .dismissEditor:
+                state.editorState = nil
+                return .none
+
+            case .saveItem(let item):
+                if let index = state.items.firstIndex(where: { $0.id == item.id }) {
+                    state.items[index] = item
+                } else {
+                    state.items.append(item)
+                }
+                state.editorState = nil
+                state.saveItems()
+                return .none
+
+            case .updateItemName(let name):
+                state.editorState?.item.name = name
+                return .none
+
+            case .updateItemIcon(let icon):
+                state.editorState?.item.icon = icon
+                return .none
+
+            case .updateItemColor(let color):
+                state.editorState?.item.color = color
+                return .none
+
+            case .updateItemType(let type):
+                state.editorState?.item.type = type
+                return .none
+
+            case .updateItemURL(let url):
+                state.editorState?.item.url = url
+                return .none
+
+            case .resetToDefaults:
+                state.items = QuickLaunchItem.defaults
+                state.saveItems()
+                return .none
+            }
+        }
+    }
+}

--- a/Projects/App/Sources/Features/QuickLaunch/QuickLaunchView.swift
+++ b/Projects/App/Sources/Features/QuickLaunch/QuickLaunchView.swift
@@ -1,0 +1,486 @@
+import ComposableArchitecture
+import SwiftUI
+import UIKit
+
+public struct QuickLaunchView: View {
+    @Bindable var store: StoreOf<QuickLaunchFeature>
+
+    private let columns = [
+        GridItem(.flexible(), spacing: 12),
+        GridItem(.flexible(), spacing: 12),
+        GridItem(.flexible(), spacing: 12),
+        GridItem(.flexible(), spacing: 12)
+    ]
+
+    public init(store: StoreOf<QuickLaunchFeature>) {
+        self.store = store
+    }
+
+    public var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                header
+                    .padding(.horizontal)
+
+                itemsGrid
+                    .padding(.horizontal)
+            }
+            .padding(.vertical)
+        }
+        .background(Color(.systemBackground))
+        .sheet(isPresented: Binding(
+            get: { store.editorState != nil },
+            set: { if !$0 { store.send(.dismissEditor) } }
+        )) {
+            QuickLaunchEditorView(store: store)
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            Text("퀵 런치")
+                .font(.title2.weight(.bold))
+
+            Spacer()
+
+            if store.isEditing {
+                Button {
+                    store.send(.resetToDefaults)
+                } label: {
+                    Text("초기화")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(.red)
+                }
+            }
+
+            Button {
+                store.send(.editModeToggled)
+            } label: {
+                Text(store.isEditing ? "완료" : "편집")
+                    .font(.subheadline.weight(.medium))
+            }
+        }
+    }
+
+    // MARK: - Items Grid
+
+    private var itemsGrid: some View {
+        LazyVGrid(columns: columns, spacing: 12) {
+            ForEach(store.items) { item in
+                QuickLaunchButton(
+                    item: item,
+                    isEditing: store.isEditing
+                ) {
+                    store.send(.itemTapped(item))
+                } onDelete: {
+                    store.send(.itemDeleted(item))
+                }
+            }
+
+            // Add Button
+            AddQuickLaunchButton {
+                store.send(.addItemTapped)
+            }
+        }
+    }
+}
+
+// MARK: - Quick Launch Button
+
+struct QuickLaunchButton: View {
+    let item: QuickLaunchFeature.QuickLaunchItem
+    let isEditing: Bool
+    let onTap: () -> Void
+    let onDelete: () -> Void
+
+    @State private var isPressed = false
+    @State private var isWiggling = false
+
+    var body: some View {
+        Button {
+            triggerHaptic()
+            onTap()
+        } label: {
+            content
+        }
+        .buttonStyle(.plain)
+        .scaleEffect(isPressed ? 0.95 : 1.0)
+        .rotationEffect(.degrees(isEditing && isWiggling ? 1.5 : 0))
+        .animation(
+            isEditing
+                ? .easeInOut(duration: 0.1).repeatForever(autoreverses: true)
+                : .default,
+            value: isWiggling
+        )
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { _ in
+                    if !isPressed {
+                        withAnimation(.spring(response: 0.2)) {
+                            isPressed = true
+                        }
+                    }
+                }
+                .onEnded { _ in
+                    withAnimation(.spring(response: 0.2)) {
+                        isPressed = false
+                    }
+                }
+        )
+        .overlay(alignment: .topTrailing) {
+            if isEditing {
+                deleteButton
+            }
+        }
+        .onChange(of: isEditing) { _, editing in
+            isWiggling = editing
+        }
+        .accessibilityLabel("\(item.name) 바로가기")
+    }
+
+    private var content: some View {
+        VStack(spacing: 8) {
+            Image(systemName: item.icon)
+                .font(.system(size: 24))
+                .foregroundStyle(.white)
+
+            Text(item.name)
+                .font(.caption2)
+                .fontWeight(.medium)
+                .foregroundStyle(.white.opacity(0.9))
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 80)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(item.color.color.gradient)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .strokeBorder(.white.opacity(0.2), lineWidth: 1)
+        )
+        .shadow(color: item.color.color.opacity(0.3), radius: 8, y: 4)
+    }
+
+    private var deleteButton: some View {
+        Button {
+            onDelete()
+        } label: {
+            Image(systemName: "xmark.circle.fill")
+                .font(.title3)
+                .foregroundStyle(.white, .red)
+        }
+        .offset(x: 8, y: -8)
+    }
+
+    private func triggerHaptic() {
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+    }
+}
+
+// MARK: - Add Quick Launch Button
+
+struct AddQuickLaunchButton: View {
+    let action: () -> Void
+
+    @State private var isPressed = false
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 8) {
+                Image(systemName: "plus")
+                    .font(.system(size: 24, weight: .medium))
+                    .foregroundStyle(Color(.secondaryLabel))
+
+                Text("추가")
+                    .font(.caption2)
+                    .fontWeight(.medium)
+                    .foregroundStyle(Color(.tertiaryLabel))
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 80)
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(Color(.tertiarySystemBackground))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16)
+                            .strokeBorder(
+                                Color(.separator),
+                                style: StrokeStyle(lineWidth: 2, dash: [8, 4])
+                            )
+                    )
+            )
+            .scaleEffect(isPressed ? 0.95 : 1.0)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("바로가기 추가")
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { _ in
+                    if !isPressed {
+                        withAnimation(.spring(response: 0.2)) {
+                            isPressed = true
+                        }
+                    }
+                }
+                .onEnded { _ in
+                    withAnimation(.spring(response: 0.2)) {
+                        isPressed = false
+                    }
+                }
+        )
+    }
+}
+
+// MARK: - Quick Launch Editor View
+
+struct QuickLaunchEditorView: View {
+    @Bindable var store: StoreOf<QuickLaunchFeature>
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                // Name
+                Section("이름") {
+                    TextField("바로가기 이름", text: Binding(
+                        get: { store.editorState?.item.name ?? "" },
+                        set: { store.send(.updateItemName($0)) }
+                    ))
+                }
+
+                // URL
+                Section("URL") {
+                    TextField("https://example.com", text: Binding(
+                        get: { store.editorState?.item.url ?? "" },
+                        set: { store.send(.updateItemURL($0)) }
+                    ))
+                    .keyboardType(.URL)
+                    .autocapitalization(.none)
+                    .autocorrectionDisabled()
+                }
+
+                // Icon
+                Section("아이콘") {
+                    QuickLaunchIconPicker(
+                        selectedIcon: store.editorState?.item.icon ?? "link"
+                    ) { icon in
+                        store.send(.updateItemIcon(icon))
+                    }
+                }
+
+                // Color
+                Section("색상") {
+                    QuickLaunchColorPicker(
+                        selectedColor: store.editorState?.item.color ?? .blue
+                    ) { color in
+                        store.send(.updateItemColor(color))
+                    }
+                }
+            }
+            .navigationTitle(store.editorState?.isNew == true ? "바로가기 추가" : "바로가기 편집")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("취소") {
+                        store.send(.dismissEditor)
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("저장") {
+                        if let item = store.editorState?.item {
+                            store.send(.saveItem(item))
+                        }
+                    }
+                    .disabled(store.editorState?.item.name.isEmpty == true ||
+                              store.editorState?.item.url.isEmpty == true)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Icon Picker
+
+struct QuickLaunchIconPicker: View {
+    let selectedIcon: String
+    let onSelect: (String) -> Void
+
+    private let icons = [
+        "link", "globe", "safari.fill", "play.tv.fill",
+        "play.rectangle.fill", "music.note", "film.fill", "gamecontroller.fill",
+        "cart.fill", "bag.fill", "creditcard.fill", "house.fill",
+        "building.2.fill", "briefcase.fill", "book.fill", "newspaper.fill",
+        "envelope.fill", "bubble.left.fill", "phone.fill", "video.fill",
+        "camera.fill", "photo.fill", "map.fill", "location.fill",
+        "cloud.fill", "doc.fill", "folder.fill", "tray.fill",
+        "chevron.left.forwardslash.chevron.right", "terminal.fill", "cpu.fill", "memorychip.fill",
+        "bubble.left.and.bubble.right.fill", "person.fill", "person.2.fill", "star.fill"
+    ]
+
+    private let columns = [
+        GridItem(.adaptive(minimum: 44), spacing: 8)
+    ]
+
+    var body: some View {
+        LazyVGrid(columns: columns, spacing: 8) {
+            ForEach(icons, id: \.self) { icon in
+                Button {
+                    onSelect(icon)
+                } label: {
+                    Image(systemName: icon)
+                        .font(.system(size: 20))
+                        .frame(width: 44, height: 44)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(selectedIcon == icon
+                                      ? Color.accentColor.opacity(0.2)
+                                      : Color(.tertiarySystemBackground))
+                        )
+                        .foregroundStyle(selectedIcon == icon ? Color.accentColor : .primary)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .strokeBorder(
+                                    selectedIcon == icon ? Color.accentColor : Color.clear,
+                                    lineWidth: 2
+                                )
+                        )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}
+
+// MARK: - Color Picker
+
+struct QuickLaunchColorPicker: View {
+    let selectedColor: QuickLaunchFeature.QuickLaunchColor
+    let onSelect: (QuickLaunchFeature.QuickLaunchColor) -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ForEach(QuickLaunchFeature.QuickLaunchColor.allCases, id: \.self) { color in
+                Button {
+                    onSelect(color)
+                } label: {
+                    Circle()
+                        .fill(color.color.gradient)
+                        .frame(width: 32, height: 32)
+                        .overlay(
+                            Circle()
+                                .strokeBorder(.white, lineWidth: selectedColor == color ? 3 : 0)
+                        )
+                        .overlay(
+                            Circle()
+                                .strokeBorder(Color(.separator), lineWidth: 1)
+                        )
+                        .shadow(color: color.color.opacity(0.3), radius: 4, y: 2)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}
+
+// MARK: - Quick Launch Section (for ProductivityView)
+
+public struct QuickLaunchSection: View {
+    @Bindable var store: StoreOf<QuickLaunchFeature>
+
+    private let columns = [
+        GridItem(.flexible(), spacing: 12),
+        GridItem(.flexible(), spacing: 12),
+        GridItem(.flexible(), spacing: 12),
+        GridItem(.flexible(), spacing: 12)
+    ]
+
+    public init(store: StoreOf<QuickLaunchFeature>) {
+        self.store = store
+    }
+
+    public var body: some View {
+        VStack(spacing: 16) {
+            // Header
+            HStack {
+                Image(systemName: "link")
+                    .foregroundStyle(.blue)
+                Text("퀵 런치")
+                    .font(.headline)
+
+                Spacer()
+
+                if store.isEditing {
+                    Button {
+                        store.send(.resetToDefaults)
+                    } label: {
+                        Text("초기화")
+                            .font(.caption)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .tint(.red)
+                }
+
+                Button {
+                    store.send(.editModeToggled)
+                } label: {
+                    Text(store.isEditing ? "완료" : "편집")
+                        .font(.caption)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+
+            // Items Grid
+            LazyVGrid(columns: columns, spacing: 12) {
+                ForEach(store.items) { item in
+                    QuickLaunchButton(
+                        item: item,
+                        isEditing: store.isEditing
+                    ) {
+                        store.send(.itemTapped(item))
+                    } onDelete: {
+                        store.send(.itemDeleted(item))
+                    }
+                }
+
+                AddQuickLaunchButton {
+                    store.send(.addItemTapped)
+                }
+            }
+        }
+        .padding()
+        .background(Color(.secondarySystemBackground).opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .sheet(isPresented: Binding(
+            get: { store.editorState != nil },
+            set: { if !$0 { store.send(.dismissEditor) } }
+        )) {
+            QuickLaunchEditorView(store: store)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    QuickLaunchView(
+        store: Store(initialState: QuickLaunchFeature.State()) {
+            QuickLaunchFeature()
+        }
+    )
+}
+
+#Preview("Section") {
+    QuickLaunchSection(
+        store: Store(initialState: QuickLaunchFeature.State()) {
+            QuickLaunchFeature()
+        }
+    )
+    .padding()
+}

--- a/Projects/App/Sources/Services/ConnectionClient.swift
+++ b/Projects/App/Sources/Services/ConnectionClient.swift
@@ -25,6 +25,7 @@ public struct ConnectionClient: Sendable {
     public var sendAppFocus: @Sendable (String, UInt32) async -> Void
     public var sendSiriCommand: @Sendable (SiriCommand.Action, String) async -> Void
     public var sendVoiceText: @Sendable (String, Bool) async -> Void
+    public var sendOpenURL: @Sendable (String) async -> Void
 }
 
 // MARK: - Events
@@ -84,7 +85,8 @@ extension ConnectionClient: DependencyKey {
             requestAppList: { await actor.requestAppList() },
             sendAppFocus: { bundleID, pid in await actor.sendAppFocus(bundleID: bundleID, pid: pid) },
             sendSiriCommand: { action, text in await actor.sendSiriCommand(action: action, text: text) },
-            sendVoiceText: { text, isFinal in await actor.sendVoiceText(text: text, isFinal: isFinal) }
+            sendVoiceText: { text, isFinal in await actor.sendVoiceText(text: text, isFinal: isFinal) },
+            sendOpenURL: { url in await actor.sendOpenURL(url: url) }
         )
     }
 
@@ -105,7 +107,8 @@ extension ConnectionClient: DependencyKey {
             requestAppList: {},
             sendAppFocus: { _, _ in },
             sendSiriCommand: { _, _ in },
-            sendVoiceText: { _, _ in }
+            sendVoiceText: { _, _ in },
+            sendOpenURL: { _ in }
         )
     }
 }
@@ -224,6 +227,10 @@ private actor ConnectionActor: SnapClientDelegate, BonjourBrowserDelegate {
 
     func sendVoiceText(text: String, isFinal: Bool) {
         client?.sendVoiceText(text: text, isFinal: isFinal)
+    }
+
+    func sendOpenURL(url: String) {
+        client?.sendOpenURL(url: url)
     }
 
     // MARK: - SnapClientDelegate

--- a/Projects/App/Sources/Services/SnapClient.swift
+++ b/Projects/App/Sources/Services/SnapClient.swift
@@ -169,6 +169,14 @@ public final class SnapClient: @unchecked Sendable {
         tcpConnection?.send(voiceText, type: .voiceText)
     }
 
+    /// URL 열기 전송 (TCP)
+    public func sendOpenURL(url: String) {
+        guard isConnected else { return }
+
+        let openURL = OpenURL(url: url)
+        tcpConnection?.send(openURL, type: .openURL)
+    }
+
     // MARK: - Private Methods
 
     private static func getDeviceID() -> String {

--- a/Projects/MacReceiver/Sources/MacReceiverApp.swift
+++ b/Projects/MacReceiver/Sources/MacReceiverApp.swift
@@ -489,6 +489,14 @@ final class ServerManager: ObservableObject {
             SiriController.shared.execute(command: command)
             logPacket("SiriCommand: \(command.action)")
 
+        case .openURL(let openURL, _):
+            if let url = URL(string: openURL.url) {
+                NSWorkspace.shared.open(url)
+                logPacket("OpenURL: \(openURL.url)")
+            } else {
+                logPacket("OpenURL: Invalid URL - \(openURL.url)")
+            }
+
         default:
             break
         }

--- a/Projects/Shared/Sources/Network/MessageType.swift
+++ b/Projects/Shared/Sources/Network/MessageType.swift
@@ -31,6 +31,8 @@ public enum MessageType: UInt8, Sendable {
     case appListResponse = 0x51
     /// 앱 포커스 전환
     case appFocus = 0x52
+    /// URL 열기
+    case openURL = 0x53
     /// 발표 제어
     case presentation = 0x60
     /// 음성 텍스트

--- a/Projects/Shared/Sources/Network/PacketDecoder.swift
+++ b/Projects/Shared/Sources/Network/PacketDecoder.swift
@@ -27,6 +27,7 @@ public enum DecodedPacket: Sendable {
     case appListRequest(AppListRequest, header: PacketHeader)
     case appListResponse(AppListResponse, header: PacketHeader)
     case appFocus(AppFocus, header: PacketHeader)
+    case openURL(OpenURL, header: PacketHeader)
     case presentation(Presentation, header: PacketHeader)
     case voiceText(VoiceText, header: PacketHeader)
     case siriCommand(SiriCommand, header: PacketHeader)
@@ -53,6 +54,7 @@ public enum DecodedPacket: Sendable {
         case .appListRequest: return .appListRequest
         case .appListResponse: return .appListResponse
         case .appFocus: return .appFocus
+        case .openURL: return .openURL
         case .presentation: return .presentation
         case .voiceText: return .voiceText
         case .siriCommand: return .siriCommand
@@ -79,6 +81,7 @@ public enum DecodedPacket: Sendable {
              .appListRequest(_, let header),
              .appListResponse(_, let header),
              .appFocus(_, let header),
+             .openURL(_, let header),
              .presentation(_, let header),
              .voiceText(_, let header),
              .siriCommand(_, let header),
@@ -155,6 +158,9 @@ public enum PacketDecoder {
             case .appFocus:
                 let message = try decoder.decode(AppFocus.self, from: payload)
                 return .appFocus(message, header: header)
+            case .openURL:
+                let message = try decoder.decode(OpenURL.self, from: payload)
+                return .openURL(message, header: header)
             case .presentation:
                 let message = try decoder.decode(Presentation.self, from: payload)
                 return .presentation(message, header: header)

--- a/Projects/Shared/Sources/Network/PacketEncoder.swift
+++ b/Projects/Shared/Sources/Network/PacketEncoder.swift
@@ -75,6 +75,11 @@ public enum PacketEncoder {
         try encode(message, type: .appFocus)
     }
 
+    /// OpenURL 인코딩
+    public static func encode(_ message: OpenURL) throws -> Data {
+        try encode(message, type: .openURL)
+    }
+
     /// Presentation 인코딩
     public static func encode(_ message: Presentation) throws -> Data {
         try encode(message, type: .presentation)

--- a/Projects/Shared/Sources/Protocol/AppSwitcherMessages.swift
+++ b/Projects/Shared/Sources/Protocol/AppSwitcherMessages.swift
@@ -55,3 +55,14 @@ public struct AppFocus: Codable, Sendable, Equatable {
         self.pid = pid
     }
 }
+
+// MARK: - OpenURL
+
+/// URL 열기 (iOS → Mac)
+public struct OpenURL: Codable, Sendable, Equatable {
+    public var url: String
+
+    public init(url: String = "") {
+        self.url = url
+    }
+}


### PR DESCRIPTION
## Summary
- 자주 사용하는 URL/앱을 빠르게 실행할 수 있는 퀵 런치 기능 구현
- iOS에서 버튼 탭 → Mac에서 기본 브라우저로 URL 열기

## Changes

### Protocol Layer (Shared)
- `MessageType.openURL` (0x53) 추가
- `OpenURL` 메시지 구조체 생성
- PacketEncoder/Decoder 업데이트

### iOS App
- `QuickLaunchFeature.swift`: TCA Reducer
  - QuickLaunchItem 모델 (name, icon, color, url)
  - UserDefaults 기반 영속성
  - 추가/편집/삭제 기능
- `QuickLaunchView.swift`: SwiftUI UI
  - 바로가기 그리드 (4열)
  - 아이콘/색상 선택 에디터
  - 편집 모드 (wiggle 애니메이션)
- `ConnectionClient.sendOpenURL` 추가
- `SnapClient.sendOpenURL` 추가

### MacReceiver
- `NSWorkspace.shared.open(URL)` 호출

### 기본 프리셋
- Netflix, YouTube, Spotify, GitHub, ChatGPT, Twitter

## Test plan
- [ ] Netflix 버튼 탭 → Mac 기본 브라우저에서 netflix.com 열기 확인
- [ ] 새 바로가기 추가 (이름, URL, 아이콘, 색상 설정)
- [ ] 바로가기 편집/삭제 확인
- [ ] 초기화 버튼으로 기본 프리셋 복원 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)