### PR TITLE
[Feat]: 홈 화면 위젯 구현

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -64,18 +64,53 @@ let project = Project(
                 "NSBonjourServices": ["_snap._tcp.", "_snap._udp."],
                 "NSSpeechRecognitionUsageDescription": "Snap uses speech recognition for voice typing.",
                 "NSMicrophoneUsageDescription": "Snap uses microphone for voice typing.",
+                "CFBundleURLTypes": [
+                    [
+                        "CFBundleURLName": "com.snap.app",
+                        "CFBundleURLSchemes": ["snap"],
+                    ],
+                ],
             ]),
             sources: ["Projects/App/Sources/**"],
             resources: ["Projects/App/Resources/**"],
             scripts: [swiftLintScript],
             dependencies: [
                 .target(name: "Shared"),
+                .target(name: "SnapWidget"),
                 .external(name: "ComposableArchitecture"),
             ],
             settings: .settings(
                 base: [
                     "DEVELOPMENT_TEAM": "",
                     "CODE_SIGN_STYLE": "Automatic",
+                ]
+            )
+        ),
+
+        // MARK: - Widget Extension
+        .target(
+            name: "SnapWidget",
+            destinations: [.iPhone, .iPad],
+            product: .appExtension,
+            bundleId: "com.snap.app.widget",
+            deploymentTargets: .iOS("17.0"),
+            infoPlist: .extendingDefault(with: [
+                "CFBundleDisplayName": "Snap Widget",
+                "CFBundleShortVersionString": "1.0.0",
+                "CFBundleVersion": "1",
+                "NSExtension": [
+                    "NSExtensionPointIdentifier": "com.apple.widgetkit-extension",
+                ],
+            ]),
+            sources: ["Projects/Widget/Sources/**"],
+            dependencies: [
+                .target(name: "Shared"),
+            ],
+            settings: .settings(
+                base: [
+                    "DEVELOPMENT_TEAM": "",
+                    "CODE_SIGN_STYLE": "Automatic",
+                    "SKIP_INSTALL": "YES",
                 ]
             )
         ),

--- a/Projects/App/Sources/Features/App/AppFeature.swift
+++ b/Projects/App/Sources/Features/App/AppFeature.swift
@@ -58,6 +58,7 @@ public struct AppFeature {
         case hideConnectionSheet
         case showSettings
         case hideSettings
+        case handleURL(URL)
     }
 
     public init() {}
@@ -146,7 +147,54 @@ public struct AppFeature {
 
             case .settings:
                 return .none
+
+            case .handleURL(let url):
+                return handleDeepLink(url: url, state: &state)
             }
+        }
+    }
+
+    // MARK: - Deep Link Handling
+
+    private func handleDeepLink(url: URL, state: inout State) -> Effect<Action> {
+        guard url.scheme == "snap" else { return .none }
+
+        let host = url.host ?? ""
+        let pathComponents = url.pathComponents.filter { $0 != "/" }
+
+        switch host {
+        case "connect":
+            state.isConnectionSheetPresented = true
+            return .none
+
+        case "trackpad":
+            state.selectedTab = .trackpad
+            return .none
+
+        case "keyboard":
+            state.selectedTab = .keyboard
+            return .none
+
+        case "macros":
+            state.selectedTab = .productivity
+            return .none
+
+        case "macro":
+            // snap://macro/{uuid}
+            guard let uuidString = pathComponents.first,
+                  let macroId = UUID(uuidString: uuidString) else {
+                return .none
+            }
+
+            state.selectedTab = .productivity
+
+            if let macro = state.productivity.macro.macros.first(where: { $0.id == macroId }) {
+                return .send(.productivity(.macro(.macroTapped(macro))))
+            }
+            return .none
+
+        default:
+            return .none
         }
     }
 }

--- a/Projects/App/Sources/SnapApp.swift
+++ b/Projects/App/Sources/SnapApp.swift
@@ -15,6 +15,9 @@ struct SnapApp: App {
                 .onChange(of: scenePhase) { _, newPhase in
                     store.send(.scenePhaseChanged(newPhase))
                 }
+                .onOpenURL { url in
+                    store.send(.handleURL(url))
+                }
         }
     }
 }

--- a/Projects/Widget/Sources/MacroWidget.swift
+++ b/Projects/Widget/Sources/MacroWidget.swift
@@ -1,0 +1,242 @@
+import SwiftUI
+import WidgetKit
+
+// MARK: - Macro Widget
+
+struct MacroWidget: Widget {
+    let kind: String = "MacroWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: MacroProvider()) { entry in
+            MacroWidgetView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName("매크로")
+        .description("자주 사용하는 매크로를 빠르게 실행합니다.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+// MARK: - Macro Item
+
+struct WidgetMacroItem: Identifiable, Codable {
+    let id: UUID
+    let name: String
+    let icon: String
+    let colorName: String
+
+    var color: Color {
+        switch colorName {
+        case "blue": return .blue
+        case "purple": return .purple
+        case "pink": return .pink
+        case "red": return .red
+        case "orange": return .orange
+        case "yellow": return .yellow
+        case "green": return .green
+        case "teal": return .teal
+        case "gray": return .gray
+        default: return .blue
+        }
+    }
+}
+
+// MARK: - Entry
+
+struct MacroEntry: TimelineEntry {
+    let date: Date
+    let macros: [WidgetMacroItem]
+}
+
+// MARK: - Provider
+
+struct MacroProvider: TimelineProvider {
+    func placeholder(in context: Context) -> MacroEntry {
+        MacroEntry(date: Date(), macros: defaultMacros)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (MacroEntry) -> Void) {
+        let macros = WidgetDataManager.loadMacros()
+        let entry = MacroEntry(date: Date(), macros: macros.isEmpty ? defaultMacros : macros)
+        completion(entry)
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<MacroEntry>) -> Void) {
+        let macros = WidgetDataManager.loadMacros()
+        let entry = MacroEntry(date: Date(), macros: macros.isEmpty ? defaultMacros : macros)
+
+        // Update every 15 minutes
+        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 15, to: Date()) ?? Date()
+        let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
+        completion(timeline)
+    }
+
+    private var defaultMacros: [WidgetMacroItem] {
+        [
+            WidgetMacroItem(id: UUID(), name: "복사", icon: "doc.on.doc", colorName: "blue"),
+            WidgetMacroItem(id: UUID(), name: "붙여넣기", icon: "doc.on.clipboard", colorName: "green"),
+            WidgetMacroItem(id: UUID(), name: "실행취소", icon: "arrow.uturn.backward", colorName: "orange"),
+            WidgetMacroItem(id: UUID(), name: "저장", icon: "square.and.arrow.down", colorName: "purple")
+        ]
+    }
+}
+
+// MARK: - Widget View
+
+struct MacroWidgetView: View {
+    var entry: MacroEntry
+
+    @Environment(\.widgetFamily) var family
+
+    var body: some View {
+        switch family {
+        case .systemSmall:
+            smallView
+        case .systemMedium:
+            mediumView
+        default:
+            smallView
+        }
+    }
+
+    private var smallView: some View {
+        VStack(spacing: 8) {
+            HStack {
+                Image(systemName: "keyboard")
+                    .foregroundStyle(.secondary)
+                Text("매크로")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+
+            LazyVGrid(columns: [
+                GridItem(.flexible(), spacing: 8),
+                GridItem(.flexible(), spacing: 8)
+            ], spacing: 8) {
+                ForEach(entry.macros.prefix(4)) { macro in
+                    if let url = URL(string: "snap://macro/\(macro.id.uuidString)") {
+                        Link(destination: url) {
+                            MacroButtonSmall(macro: macro)
+                        }
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var mediumView: some View {
+        VStack(spacing: 8) {
+            HStack {
+                Image(systemName: "keyboard")
+                    .foregroundStyle(.secondary)
+                Text("매크로")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+
+                if let moreURL = URL(string: "snap://macros") {
+                    Link(destination: moreURL) {
+                        Text("더보기")
+                            .font(.caption)
+                            .foregroundStyle(Color.accentColor)
+                    }
+                }
+            }
+
+            LazyVGrid(columns: [
+                GridItem(.flexible(), spacing: 8),
+                GridItem(.flexible(), spacing: 8),
+                GridItem(.flexible(), spacing: 8),
+                GridItem(.flexible(), spacing: 8)
+            ], spacing: 8) {
+                ForEach(entry.macros.prefix(8)) { macro in
+                    if let url = URL(string: "snap://macro/\(macro.id.uuidString)") {
+                        Link(destination: url) {
+                            MacroButtonMedium(macro: macro)
+                        }
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Macro Button Small
+
+struct MacroButtonSmall: View {
+    let macro: WidgetMacroItem
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Image(systemName: macro.icon)
+                .font(.system(size: 18))
+                .foregroundStyle(.white)
+
+            Text(macro.name)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.white.opacity(0.9))
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(macro.color.gradient)
+        )
+    }
+}
+
+// MARK: - Macro Button Medium
+
+struct MacroButtonMedium: View {
+    let macro: WidgetMacroItem
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Image(systemName: macro.icon)
+                .font(.system(size: 20))
+                .foregroundStyle(.white)
+
+            Text(macro.name)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.white.opacity(0.9))
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 50)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(macro.color.gradient)
+        )
+    }
+}
+
+// MARK: - Preview
+
+#Preview(as: .systemSmall) {
+    MacroWidget()
+} timeline: {
+    MacroEntry(date: .now, macros: [
+        WidgetMacroItem(id: UUID(), name: "복사", icon: "doc.on.doc", colorName: "blue"),
+        WidgetMacroItem(id: UUID(), name: "붙여넣기", icon: "doc.on.clipboard", colorName: "green"),
+        WidgetMacroItem(id: UUID(), name: "실행취소", icon: "arrow.uturn.backward", colorName: "orange"),
+        WidgetMacroItem(id: UUID(), name: "저장", icon: "square.and.arrow.down", colorName: "purple")
+    ])
+}
+
+#Preview(as: .systemMedium) {
+    MacroWidget()
+} timeline: {
+    MacroEntry(date: .now, macros: [
+        WidgetMacroItem(id: UUID(), name: "복사", icon: "doc.on.doc", colorName: "blue"),
+        WidgetMacroItem(id: UUID(), name: "붙여넣기", icon: "doc.on.clipboard", colorName: "green"),
+        WidgetMacroItem(id: UUID(), name: "실행취소", icon: "arrow.uturn.backward", colorName: "orange"),
+        WidgetMacroItem(id: UUID(), name: "저장", icon: "square.and.arrow.down", colorName: "purple"),
+        WidgetMacroItem(id: UUID(), name: "잘라내기", icon: "scissors", colorName: "red"),
+        WidgetMacroItem(id: UUID(), name: "스크린샷", icon: "camera.viewfinder", colorName: "teal"),
+        WidgetMacroItem(id: UUID(), name: "새로고침", icon: "arrow.clockwise", colorName: "pink"),
+        WidgetMacroItem(id: UUID(), name: "전체선택", icon: "selection.pin.in.out", colorName: "gray")
+    ])
+}

--- a/Projects/Widget/Sources/QuickConnectWidget.swift
+++ b/Projects/Widget/Sources/QuickConnectWidget.swift
@@ -1,0 +1,196 @@
+import SwiftUI
+import WidgetKit
+
+// MARK: - Quick Connect Widget
+
+struct QuickConnectWidget: Widget {
+    let kind: String = "QuickConnectWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: QuickConnectProvider()) { entry in
+            QuickConnectWidgetView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName("빠른 연결")
+        .description("Mac과 빠르게 연결합니다.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+// MARK: - Entry
+
+struct QuickConnectEntry: TimelineEntry {
+    let date: Date
+    let isConnected: Bool
+    let deviceName: String?
+}
+
+// MARK: - Provider
+
+struct QuickConnectProvider: TimelineProvider {
+    func placeholder(in context: Context) -> QuickConnectEntry {
+        QuickConnectEntry(date: Date(), isConnected: false, deviceName: nil)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (QuickConnectEntry) -> Void) {
+        let entry = QuickConnectEntry(
+            date: Date(),
+            isConnected: WidgetDataManager.isConnected,
+            deviceName: WidgetDataManager.connectedDeviceName
+        )
+        completion(entry)
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<QuickConnectEntry>) -> Void) {
+        let entry = QuickConnectEntry(
+            date: Date(),
+            isConnected: WidgetDataManager.isConnected,
+            deviceName: WidgetDataManager.connectedDeviceName
+        )
+
+        // Update every 5 minutes
+        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 5, to: Date()) ?? Date()
+        let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
+        completion(timeline)
+    }
+}
+
+// MARK: - Widget View
+
+struct QuickConnectWidgetView: View {
+    var entry: QuickConnectEntry
+
+    @Environment(\.widgetFamily) var family
+
+    var body: some View {
+        switch family {
+        case .systemSmall:
+            smallView
+        case .systemMedium:
+            mediumView
+        default:
+            smallView
+        }
+    }
+
+    private var smallView: some View {
+        VStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(entry.isConnected ? Color.green.opacity(0.2) : Color.gray.opacity(0.2))
+                    .frame(width: 60, height: 60)
+
+                Image(systemName: entry.isConnected ? "wifi" : "wifi.slash")
+                    .font(.system(size: 28))
+                    .foregroundStyle(entry.isConnected ? .green : .secondary)
+            }
+
+            VStack(spacing: 4) {
+                Text(entry.isConnected ? "연결됨" : "연결 안됨")
+                    .font(.headline)
+                    .foregroundStyle(entry.isConnected ? .primary : .secondary)
+
+                if let deviceName = entry.deviceName, entry.isConnected {
+                    Text(deviceName)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .widgetURL(URL(string: "snap://connect"))
+    }
+
+    private var mediumView: some View {
+        HStack(spacing: 16) {
+            // Connection Status
+            ZStack {
+                Circle()
+                    .fill(entry.isConnected ? Color.green.opacity(0.2) : Color.gray.opacity(0.2))
+                    .frame(width: 70, height: 70)
+
+                Image(systemName: entry.isConnected ? "wifi" : "wifi.slash")
+                    .font(.system(size: 32))
+                    .foregroundStyle(entry.isConnected ? .green : .secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Snap")
+                    .font(.title2.weight(.bold))
+
+                if entry.isConnected {
+                    HStack(spacing: 4) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                        Text(entry.deviceName ?? "Mac")
+                            .foregroundStyle(.secondary)
+                    }
+                    .font(.subheadline)
+                } else {
+                    Text("탭하여 연결")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+
+            // Quick Actions
+            if entry.isConnected {
+                VStack(spacing: 8) {
+                    if let trackpadURL = URL(string: "snap://trackpad") {
+                        Link(destination: trackpadURL) {
+                            QuickActionButton(icon: "hand.draw", label: "트랙패드")
+                        }
+                    }
+                    if let keyboardURL = URL(string: "snap://keyboard") {
+                        Link(destination: keyboardURL) {
+                            QuickActionButton(icon: "keyboard", label: "키보드")
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 4)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .widgetURL(URL(string: "snap://connect"))
+    }
+}
+
+// MARK: - Quick Action Button
+
+struct QuickActionButton: View {
+    let icon: String
+    let label: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 14))
+            Text(label)
+                .font(.caption)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Color.accentColor.opacity(0.15))
+        .clipShape(Capsule())
+        .foregroundStyle(Color.accentColor)
+    }
+}
+
+// MARK: - Preview
+
+#Preview(as: .systemSmall) {
+    QuickConnectWidget()
+} timeline: {
+    QuickConnectEntry(date: .now, isConnected: false, deviceName: nil)
+    QuickConnectEntry(date: .now, isConnected: true, deviceName: "MacBook Pro")
+}
+
+#Preview(as: .systemMedium) {
+    QuickConnectWidget()
+} timeline: {
+    QuickConnectEntry(date: .now, isConnected: false, deviceName: nil)
+    QuickConnectEntry(date: .now, isConnected: true, deviceName: "MacBook Pro")
+}

--- a/Projects/Widget/Sources/SnapWidgetBundle.swift
+++ b/Projects/Widget/Sources/SnapWidgetBundle.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+import WidgetKit
+
+@main
+struct SnapWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        QuickConnectWidget()
+        MacroWidget()
+    }
+}

--- a/Projects/Widget/Sources/WidgetDataManager.swift
+++ b/Projects/Widget/Sources/WidgetDataManager.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+// MARK: - Widget Data Manager
+
+/// Manages shared data between the main app and widgets
+enum WidgetDataManager {
+    // App Group identifier for data sharing
+    private static let appGroupIdentifier = "group.com.snap.app"
+
+    private static var userDefaults: UserDefaults? {
+        UserDefaults(suiteName: appGroupIdentifier)
+    }
+
+    // MARK: - Keys
+
+    private static let isConnectedKey = "widget.isConnected"
+    private static let deviceNameKey = "widget.deviceName"
+    private static let macrosKey = "widget.macros"
+
+    // MARK: - Connection Status
+
+    static var isConnected: Bool {
+        userDefaults?.bool(forKey: isConnectedKey) ?? false
+    }
+
+    static var connectedDeviceName: String? {
+        userDefaults?.string(forKey: deviceNameKey)
+    }
+
+    static func updateConnectionStatus(isConnected: Bool, deviceName: String?) {
+        userDefaults?.set(isConnected, forKey: isConnectedKey)
+        userDefaults?.set(deviceName, forKey: deviceNameKey)
+    }
+
+    // MARK: - Macros
+
+    static func loadMacros() -> [WidgetMacroItem] {
+        guard let data = userDefaults?.data(forKey: macrosKey),
+              let macros = try? JSONDecoder().decode([WidgetMacroItem].self, from: data) else {
+            return []
+        }
+        return macros
+    }
+
+    static func saveMacros(_ macros: [WidgetMacroItem]) {
+        if let data = try? JSONEncoder().encode(macros) {
+            userDefaults?.set(data, forKey: macrosKey)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- QuickConnectWidget: 연결 상태 표시 및 빠른 연결 지원 (Small/Medium 크기)
- MacroWidget: 자주 사용하는 매크로 빠른 실행 (Small/Medium 크기)
- URL Scheme 핸들링으로 위젯에서 앱 특정 화면 직접 이동

## Changes
| 파일 | 설명 |
|------|------|
| `Project.swift` | SnapWidget 타겟 추가, URL Scheme 등록 |
| `AppFeature.swift` | Deep link 핸들링 로직 구현 |
| `SnapApp.swift` | onOpenURL 핸들러 연결 |
| `Projects/Widget/` | 위젯 소스 파일 4개 생성 |

## Supported URLs
- `snap://connect` - 연결 시트 표시
- `snap://trackpad` - 트랙패드 탭 이동
- `snap://keyboard` - 키보드 탭 이동
- `snap://macros` - More 탭 이동
- `snap://macro/{uuid}` - 특정 매크로 실행

## Test plan
- [ ] 위젯 추가 후 Small/Medium 크기 정상 표시 확인
- [ ] QuickConnectWidget 탭 시 앱 연결 화면 이동 확인
- [ ] MacroWidget에서 매크로 탭 시 해당 매크로 실행 확인
- [ ] 연결 상태에 따른 위젯 UI 변경 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)