### PR TITLE
[Feat]: iOS 물리 볼륨 버튼으로 Mac 볼륨 제어 (#60)

### DIFF
--- a/Projects/App/Sources/Features/Media/MediaFeature.swift
+++ b/Projects/App/Sources/Features/Media/MediaFeature.swift
@@ -9,6 +9,7 @@ public struct MediaFeature {
         public var isPlaying: Bool = false
         public var volume: Float = 0.5
         public var isMuted: Bool = false
+        public var isHardwareVolumeControlEnabled: Bool = true
 
         public init() {}
     }
@@ -24,6 +25,11 @@ public struct MediaFeature {
         case volumeDownTapped
         case muteTapped
         case volumeChanged(Float)
+
+        // Hardware Volume Button
+        case hardwareVolumeUp
+        case hardwareVolumeDown
+        case setHardwareVolumeControlEnabled(Bool)
 
         // State Updates
         case setIsPlaying(Bool)
@@ -92,6 +98,27 @@ public struct MediaFeature {
             case .nowPlayingInfoReceived(let info):
                 state.nowPlayingInfo = info
                 state.isPlaying = info.isPlaying
+                return .none
+
+            case .hardwareVolumeUp:
+                guard state.isHardwareVolumeControlEnabled else { return .none }
+                state.volume = min(1.0, state.volume + 0.1)
+                if state.isMuted {
+                    state.isMuted = false
+                }
+                return .run { [volume = state.volume] _ in
+                    await client.sendMediaControl(.volumeUp, volume)
+                }
+
+            case .hardwareVolumeDown:
+                guard state.isHardwareVolumeControlEnabled else { return .none }
+                state.volume = max(0.0, state.volume - 0.1)
+                return .run { [volume = state.volume] _ in
+                    await client.sendMediaControl(.volumeDown, volume)
+                }
+
+            case .setHardwareVolumeControlEnabled(let enabled):
+                state.isHardwareVolumeControlEnabled = enabled
                 return .none
             }
         }

--- a/Projects/App/Sources/Features/Media/MediaView.swift
+++ b/Projects/App/Sources/Features/Media/MediaView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 public struct MediaView: View {
     @Bindable var store: StoreOf<MediaFeature>
+    @StateObject private var volumeHandler = VolumeButtonHandler()
 
     public init(store: StoreOf<MediaFeature>) {
         self.store = store
@@ -23,10 +24,38 @@ public struct MediaView: View {
             // Volume Controls
             volumeControls
 
+            // Hardware Volume Toggle
+            hardwareVolumeToggle
+
             Spacer()
         }
         .padding()
         .background(Color(.systemBackground))
+        .onAppear {
+            if store.isHardwareVolumeControlEnabled {
+                setupVolumeHandler()
+            }
+        }
+        .onDisappear {
+            volumeHandler.stop()
+        }
+        .onChange(of: store.isHardwareVolumeControlEnabled) { _, isEnabled in
+            if isEnabled {
+                setupVolumeHandler()
+            } else {
+                volumeHandler.stop()
+            }
+        }
+    }
+
+    private func setupVolumeHandler() {
+        volumeHandler.onVolumeUp = { [store] in
+            store.send(.hardwareVolumeUp)
+        }
+        volumeHandler.onVolumeDown = { [store] in
+            store.send(.hardwareVolumeDown)
+        }
+        volumeHandler.start()
     }
 
     // MARK: - Now Playing Area
@@ -234,6 +263,36 @@ public struct MediaView: View {
             }
             .accessibilityLabel(store.isMuted ? "음소거 해제" : "음소거")
         }
+    }
+
+    // MARK: - Hardware Volume Toggle
+
+    private var hardwareVolumeToggle: some View {
+        Toggle(isOn: $store.isHardwareVolumeControlEnabled.sending(\.setHardwareVolumeControlEnabled)) {
+            HStack(spacing: 12) {
+                Image(systemName: "iphone.radiowaves.left.and.right")
+                    .font(.body)
+                    .foregroundStyle(Color(.secondaryLabel))
+                    .frame(width: 24)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Hardware Volume Buttons")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(Color(.label))
+
+                    Text("Use iPhone volume buttons to control Mac")
+                        .font(.caption)
+                        .foregroundStyle(Color(.tertiaryLabel))
+                }
+            }
+        }
+        .toggleStyle(.switch)
+        .padding(.horizontal)
+        .padding(.vertical, 12)
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal)
+        .accessibilityLabel("하드웨어 볼륨 버튼 사용")
     }
 }
 

--- a/Projects/App/Sources/Services/VolumeButtonHandler.swift
+++ b/Projects/App/Sources/Services/VolumeButtonHandler.swift
@@ -1,0 +1,128 @@
+import AVFoundation
+import Combine
+import MediaPlayer
+import os.log
+import UIKit
+
+/// iOS 물리 볼륨 버튼 이벤트 감지
+@MainActor
+public final class VolumeButtonHandler: ObservableObject {
+    // MARK: - Published Properties
+
+    @Published public private(set) var currentVolume: Float = 0.5
+
+    // MARK: - Callbacks
+
+    public var onVolumeUp: (() -> Void)?
+    public var onVolumeDown: (() -> Void)?
+
+    // MARK: - Private Properties
+
+    private var volumeView: MPVolumeView?
+    private var volumeObservation: NSKeyValueObservation?
+    private var lastVolume: Float = 0.5
+    private var isActive: Bool = false
+
+    // Volume change detection threshold
+    private let volumeChangeThreshold: Float = 0.01
+
+    private let logger = Logger(subsystem: "com.snap.app", category: "VolumeButtonHandler")
+
+    // MARK: - Initialization
+
+    public init() {}
+
+    // MARK: - Public Methods
+
+    /// 볼륨 버튼 감지 시작
+    public func start() {
+        guard !isActive else { return }
+        isActive = true
+
+        setupAudioSession()
+        setupVolumeView()
+        startObservingVolume()
+    }
+
+    /// 볼륨 버튼 감지 중지
+    public func stop() {
+        isActive = false
+        volumeObservation?.invalidate()
+        volumeObservation = nil
+        volumeView?.removeFromSuperview()
+        volumeView = nil
+    }
+
+    // MARK: - Private Methods
+
+    private func setupAudioSession() {
+        do {
+            let audioSession = AVAudioSession.sharedInstance()
+            try audioSession.setCategory(.playback, mode: .default, options: [.mixWithOthers])
+            try audioSession.setActive(true)
+            lastVolume = audioSession.outputVolume
+            currentVolume = lastVolume
+        } catch {
+            logger.error("Failed to setup audio session: \(error.localizedDescription)")
+        }
+    }
+
+    private func setupVolumeView() {
+        // MPVolumeView를 화면 밖에 배치하여 시스템 볼륨 UI 숨기기
+        let volumeView = MPVolumeView(frame: CGRect(x: -1000, y: -1000, width: 1, height: 1))
+        volumeView.setRouteButtonImage(nil, for: .normal)
+        volumeView.showsVolumeSlider = true
+        volumeView.alpha = 0.01
+
+        // 현재 윈도우에 추가
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+           let window = windowScene.windows.first {
+            window.addSubview(volumeView)
+        }
+
+        self.volumeView = volumeView
+    }
+
+    private func startObservingVolume() {
+        let audioSession = AVAudioSession.sharedInstance()
+
+        volumeObservation = audioSession.observe(\.outputVolume, options: [.new, .old]) { [weak self] _, change in
+            let newVolume = change.newValue ?? 0.5
+            let oldVolume = change.oldValue ?? 0.5
+
+            // 볼륨 변경 감지
+            let volumeDiff = newVolume - oldVolume
+
+            Task { @MainActor [weak self] in
+                guard let self = self, self.isActive else { return }
+                guard abs(volumeDiff) > self.volumeChangeThreshold else { return }
+
+                self.currentVolume = newVolume
+
+                if volumeDiff > 0 {
+                    self.onVolumeUp?()
+                } else {
+                    self.onVolumeDown?()
+                }
+
+                self.lastVolume = newVolume
+            }
+        }
+    }
+
+    /// 시스템 볼륨을 중간값으로 리셋 (연속 감지를 위해)
+    public func resetSystemVolume() {
+        // 볼륨이 0 또는 1에 도달하면 더 이상 버튼을 감지할 수 없으므로
+        // 중간값으로 리셋하는 옵션 제공
+        guard let slider = volumeView?.subviews.first(where: { $0 is UISlider }) as? UISlider else {
+            return
+        }
+
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(100))
+            slider.value = 0.5
+            self.lastVolume = 0.5
+            self.currentVolume = 0.5
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- VolumeButtonHandler 서비스 추가: AVAudioSession KVO를 사용하여 물리 볼륨 버튼 이벤트 감지
- MediaFeature에 hardwareVolumeUp/Down 액션 및 설정 상태 추가
- MediaView에 하드웨어 볼륨 제어 토글 UI 추가
- MPVolumeView를 화면 밖에 배치하여 시스템 볼륨 UI 숨기기

## Test plan
- [ ] iPhone에서 물리 볼륨 버튼을 눌러 Mac 볼륨이 변경되는지 확인
- [ ] 시스템 볼륨 UI가 표시되지 않는지 확인
- [ ] 하드웨어 볼륨 제어 토글이 정상 동작하는지 확인
- [ ] 토글 비활성화 시 물리 버튼이 일반 볼륨 조절로 동작하는지 확인

Close #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)