### PR TITLE
[Feat]: 페어링 코드 인증 시스템 구현 (#20)

### DIFF
--- a/Projects/App/Sources/Features/Connection/ConnectionFeature.swift
+++ b/Projects/App/Sources/Features/Connection/ConnectionFeature.swift
@@ -13,6 +13,11 @@ public struct ConnectionFeature: Sendable {
         public var latency: TimeInterval = 0
         public var signalStrength: SignalStrength = .unknown
 
+        // Pairing
+        public var isPairingRequired: Bool = false
+        public var pairingServerName: String = ""
+        public var pairingPinCode: String = ""
+
         public init() {}
     }
 
@@ -33,6 +38,11 @@ public struct ConnectionFeature: Sendable {
 
         // Now Playing
         case nowPlayingInfoReceived(NowPlayingInfo)
+
+        // Pairing
+        case pairingPinCodeChanged(String)
+        case submitPairingPin
+        case cancelPairing
 
         // Error
         case errorOccurred(ConnectionError)
@@ -117,6 +127,8 @@ public struct ConnectionFeature: Sendable {
             case .connectionEvent(let event):
                 switch event {
                 case .connected(let serverName):
+                    state.isPairingRequired = false
+                    state.pairingPinCode = ""
                     if case .connecting(var device) = state.status {
                         device.name = serverName
                         state.status = .connected(device)
@@ -126,6 +138,8 @@ public struct ConnectionFeature: Sendable {
                 case .disconnected(let errorMessage):
                     state.status = .disconnected
                     state.connectedDevice = nil
+                    state.isPairingRequired = false
+                    state.pairingPinCode = ""
                     if let message = errorMessage {
                         state.lastError = .connectionLost(message)
                     }
@@ -145,6 +159,21 @@ public struct ConnectionFeature: Sendable {
                     if case .connecting = state.status {
                         state.status = .disconnected
                     }
+
+                case .pairingRequired(let serverName):
+                    state.isPairingRequired = true
+                    state.pairingServerName = serverName
+                    state.pairingPinCode = ""
+
+                case .pairingResult(let success, let message):
+                    if success {
+                        state.isPairingRequired = false
+                        state.pairingPinCode = ""
+                        // 연결은 서버가 handshake 응답 후 처리됨
+                    } else {
+                        state.lastError = .pairingFailed(message)
+                        state.pairingPinCode = ""
+                    }
                 }
                 return .none
 
@@ -159,6 +188,26 @@ public struct ConnectionFeature: Sendable {
             case .focusApp(let bundleID, let pid):
                 return .run { _ in
                     await connectionClient.sendAppFocus(bundleID, pid)
+                }
+
+            case .pairingPinCodeChanged(let pin):
+                // 4자리 숫자만 허용
+                let filtered = String(pin.filter { $0.isNumber }.prefix(4))
+                state.pairingPinCode = filtered
+                return .none
+
+            case .submitPairingPin:
+                guard state.pairingPinCode.count == 4 else { return .none }
+                let pinCode = state.pairingPinCode
+                return .run { _ in
+                    await connectionClient.sendPairingResponse(pinCode)
+                }
+
+            case .cancelPairing:
+                state.isPairingRequired = false
+                state.pairingPinCode = ""
+                return .run { _ in
+                    await connectionClient.disconnect()
                 }
 
             case .errorOccurred(let error):

--- a/Projects/App/Sources/Models/Device.swift
+++ b/Projects/App/Sources/Models/Device.swift
@@ -66,4 +66,5 @@ public enum ConnectionError: Error, Equatable, Sendable {
     case timeout
     case disconnected
     case protocolError(String)
+    case pairingFailed(String)
 }

--- a/Projects/App/Sources/Services/ConnectionClient.swift
+++ b/Projects/App/Sources/Services/ConnectionClient.swift
@@ -27,6 +27,9 @@ public struct ConnectionClient: Sendable {
     public var sendSiriCommand: @Sendable (SiriCommand.Action, String) async -> Void
     public var sendVoiceText: @Sendable (String, Bool) async -> Void
     public var sendOpenURL: @Sendable (String) async -> Void
+
+    // Pairing
+    public var sendPairingResponse: @Sendable (String) async -> Void
 }
 
 // MARK: - Events
@@ -56,6 +59,9 @@ public enum ConnectionEvent: Equatable, Sendable {
     case disconnected(error: String?)
     case packet(PacketEvent)
     case error(String)
+    // Pairing
+    case pairingRequired(serverName: String)
+    case pairingResult(success: Bool, message: String)
 }
 
 public enum PacketEvent: Equatable, Sendable {
@@ -88,7 +94,8 @@ extension ConnectionClient: DependencyKey {
             sendAppFocus: { bundleID, pid in await actor.sendAppFocus(bundleID: bundleID, pid: pid) },
             sendSiriCommand: { action, text in await actor.sendSiriCommand(action: action, text: text) },
             sendVoiceText: { text, isFinal in await actor.sendVoiceText(text: text, isFinal: isFinal) },
-            sendOpenURL: { url in await actor.sendOpenURL(url: url) }
+            sendOpenURL: { url in await actor.sendOpenURL(url: url) },
+            sendPairingResponse: { pin in await actor.sendPairingResponse(pinCode: pin) }
         )
     }
 
@@ -111,7 +118,8 @@ extension ConnectionClient: DependencyKey {
             sendAppFocus: { _, _ in },
             sendSiriCommand: { _, _ in },
             sendVoiceText: { _, _ in },
-            sendOpenURL: { _ in }
+            sendOpenURL: { _ in },
+            sendPairingResponse: { _ in }
         )
     }
 }
@@ -240,6 +248,10 @@ private actor ConnectionActor: SnapClientDelegate, BonjourBrowserDelegate {
         client?.sendOpenURL(url: url)
     }
 
+    func sendPairingResponse(pinCode: String) {
+        client?.sendPairingResponse(pinCode: pinCode)
+    }
+
     // MARK: - SnapClientDelegate
 
     nonisolated func clientDidConnect(_ client: SnapClient) {
@@ -292,6 +304,26 @@ private actor ConnectionActor: SnapClientDelegate, BonjourBrowserDelegate {
 
     private func handleError(_ error: Error) {
         connectionContinuation?.yield(.error(error.localizedDescription))
+    }
+
+    nonisolated func client(_ client: SnapClient, didReceivePairingChallenge challenge: PairingChallenge) {
+        Task {
+            await self.handlePairingChallenge(challenge)
+        }
+    }
+
+    private func handlePairingChallenge(_ challenge: PairingChallenge) {
+        connectionContinuation?.yield(.pairingRequired(serverName: challenge.deviceName))
+    }
+
+    nonisolated func client(_ client: SnapClient, didReceivePairingResult result: PairingResult) {
+        Task {
+            await self.handlePairingResult(result)
+        }
+    }
+
+    private func handlePairingResult(_ result: PairingResult) {
+        connectionContinuation?.yield(.pairingResult(success: result.isSuccess, message: result.message))
     }
 
     // MARK: - BonjourBrowserDelegate

--- a/Projects/App/Sources/Services/SnapClient.swift
+++ b/Projects/App/Sources/Services/SnapClient.swift
@@ -10,6 +10,10 @@ public protocol SnapClientDelegate: AnyObject {
     func clientDidDisconnect(_ client: SnapClient, error: Error?)
     func client(_ client: SnapClient, didReceive packet: DecodedPacket)
     func client(_ client: SnapClient, didFailWithError error: Error)
+    /// 페어링 PIN 입력 요청
+    func client(_ client: SnapClient, didReceivePairingChallenge challenge: PairingChallenge)
+    /// 페어링 결과 수신
+    func client(_ client: SnapClient, didReceivePairingResult result: PairingResult)
 }
 
 /// Snap 클라이언트 (iOS)
@@ -185,6 +189,16 @@ public final class SnapClient: @unchecked Sendable {
         tcpConnection?.send(openURL, type: .openURL)
     }
 
+    /// 페어링 응답 전송 (TCP)
+    public func sendPairingResponse(pinCode: String) {
+        let response = PairingResponse(
+            pinCode: pinCode,
+            deviceName: deviceName,
+            deviceID: deviceID
+        )
+        tcpConnection?.send(response, type: .pairingResponse)
+    }
+
     // MARK: - Private Methods
 
     private static func getDeviceID() -> String {
@@ -273,6 +287,14 @@ extension SnapClient: TCPConnectionDelegate {
         switch packet {
         case .handshake(let handshake, _):
             handleHandshakeResponse(handshake)
+
+        case .pairingChallenge(let challenge, _):
+            // 페어링 챌린지 수신 - PIN 입력 필요
+            delegate?.client(self, didReceivePairingChallenge: challenge)
+
+        case .pairingResult(let result, _):
+            // 페어링 결과 수신
+            delegate?.client(self, didReceivePairingResult: result)
 
         case .heartbeat(let heartbeat, _):
             heartbeatManager?.didReceiveHeartbeat()

--- a/Projects/App/Sources/Views/AppView.swift
+++ b/Projects/App/Sources/Views/AppView.swift
@@ -93,6 +93,22 @@ public struct AppView: View {
                 store.send(.hideSettings)
             }
         }
+        .sheet(
+            isPresented: Binding(
+                get: { store.connection.isPairingRequired },
+                set: { if !$0 { store.send(.connection(.cancelPairing)) } }
+            )
+        ) {
+            PairingPinView(
+                serverName: store.connection.pairingServerName,
+                pinCode: Binding(
+                    get: { store.connection.pairingPinCode },
+                    set: { store.send(.connection(.pairingPinCodeChanged($0))) }
+                ),
+                onSubmit: { store.send(.connection(.submitPairingPin)) },
+                onCancel: { store.send(.connection(.cancelPairing)) }
+            )
+        }
         .onAppear {
             store.send(.onAppear)
         }
@@ -295,6 +311,127 @@ struct ConnectionSheetView: View {
                         onDismiss()
                     }
                 }
+            }
+        }
+    }
+}
+
+// MARK: - Pairing PIN View
+
+struct PairingPinView: View {
+    let serverName: String
+    @Binding var pinCode: String
+    let onSubmit: () -> Void
+    let onCancel: () -> Void
+
+    @FocusState private var isTextFieldFocused: Bool
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 32) {
+                Spacer()
+
+                // Icon
+                ZStack {
+                    Circle()
+                        .fill(Color.blue.opacity(0.1))
+                        .frame(width: 100, height: 100)
+
+                    Image(systemName: "lock.shield")
+                        .font(.system(size: 44))
+                        .foregroundStyle(.blue)
+                }
+
+                // Title
+                VStack(spacing: 8) {
+                    Text("Enter PIN Code")
+                        .font(.title2.weight(.bold))
+
+                    Text("Enter the 4-digit PIN shown on\n\(serverName)")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+
+                // PIN Input
+                VStack(spacing: 16) {
+                    // Hidden text field
+                    TextField("", text: $pinCode)
+                        .keyboardType(.numberPad)
+                        .textContentType(.oneTimeCode)
+                        .focused($isTextFieldFocused)
+                        .opacity(0)
+                        .frame(width: 1, height: 1)
+
+                    // PIN Display
+                    HStack(spacing: 16) {
+                        ForEach(0..<4, id: \.self) { index in
+                            pinDigitView(at: index)
+                        }
+                    }
+                    .onTapGesture {
+                        isTextFieldFocused = true
+                    }
+                }
+
+                Spacer()
+
+                // Submit Button
+                Button {
+                    onSubmit()
+                } label: {
+                    Text("Connect")
+                        .font(.headline)
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 50)
+                        .background(pinCode.count == 4 ? Color.blue : Color.gray)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+                .disabled(pinCode.count != 4)
+                .padding(.horizontal)
+
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("Pairing")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") {
+                        onCancel()
+                    }
+                }
+            }
+            .onAppear {
+                isTextFieldFocused = true
+            }
+        }
+        .interactiveDismissDisabled()
+    }
+
+    @ViewBuilder
+    private func pinDigitView(at index: Int) -> some View {
+        let digit = pinCode.count > index ? String(pinCode[pinCode.index(pinCode.startIndex, offsetBy: index)]) : ""
+        let isFilled = !digit.isEmpty
+
+        ZStack {
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(isFilled ? Color.blue : Color(.separator), lineWidth: 2)
+                .frame(width: 56, height: 72)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(Color(.secondarySystemBackground))
+                )
+
+            if isFilled {
+                Text(digit)
+                    .font(.system(size: 32, weight: .semibold, design: .rounded))
+                    .foregroundStyle(Color(.label))
+            } else {
+                Circle()
+                    .fill(Color(.tertiaryLabel))
+                    .frame(width: 12, height: 12)
             }
         }
     }

--- a/Projects/MacReceiver/Sources/MacReceiverApp.swift
+++ b/Projects/MacReceiver/Sources/MacReceiverApp.swift
@@ -344,6 +344,11 @@ final class ServerManager: ObservableObject {
     @Published var lastError: String?
     @Published var receivedPackets: [String] = []
 
+    // Pairing
+    @Published var isPairingInProgress: Bool = false
+    @Published var pairingDeviceName: String = ""
+    @Published var pairingPinCode: String = ""
+
     private var server: SnapServer?
     private var nowPlayingTimer: Timer?
     private var lastNowPlayingInfo: NowPlayingInfo?
@@ -568,6 +573,27 @@ extension ServerManager: SnapServerDelegate {
             self.logPacket("Error: \(error.localizedDescription)")
         }
     }
+
+    nonisolated func server(_ server: SnapServer, showPairingPIN pin: String, forDevice deviceName: String) {
+        Task { @MainActor in
+            self.isPairingInProgress = true
+            self.pairingDeviceName = deviceName
+            self.pairingPinCode = pin
+            self.logPacket("Pairing: PIN \(pin) for \(deviceName)")
+        }
+    }
+
+    nonisolated func server(_ server: SnapServer, didCompletePairing success: Bool, deviceName: String) {
+        Task { @MainActor in
+            self.isPairingInProgress = false
+            self.pairingPinCode = ""
+            if success {
+                self.logPacket("Pairing successful: \(deviceName)")
+            } else {
+                self.logPacket("Pairing failed: \(deviceName)")
+            }
+        }
+    }
 }
 
 // MARK: - Content View
@@ -576,25 +602,73 @@ struct ContentView: View {
     @ObservedObject var serverManager: ServerManager
 
     var body: some View {
-        VStack(spacing: 20) {
-            // Status Header
-            statusHeader
+        ZStack {
+            VStack(spacing: 20) {
+                // Status Header
+                statusHeader
 
-            Divider()
+                Divider()
 
-            // Connection Info
-            connectionInfo
+                // Connection Info
+                connectionInfo
 
-            Divider()
+                Divider()
 
-            // Log View
-            logView
+                // Log View
+                logView
 
-            // Controls
-            controls
+                // Controls
+                controls
+            }
+            .frame(width: 400, height: 400)
+            .padding()
+
+            // Pairing Overlay
+            if serverManager.isPairingInProgress {
+                pairingOverlay
+            }
         }
-        .frame(width: 400, height: 400)
-        .padding()
+    }
+
+    @ViewBuilder
+    private var pairingOverlay: some View {
+        ZStack {
+            Color.black.opacity(0.7)
+                .ignoresSafeArea()
+
+            VStack(spacing: 24) {
+                Image(systemName: "lock.shield")
+                    .font(.system(size: 48))
+                    .foregroundStyle(.blue)
+
+                Text("Pairing Request")
+                    .font(.title2.bold())
+
+                Text("'\(serverManager.pairingDeviceName)' is trying to connect")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                // PIN Display
+                HStack(spacing: 16) {
+                    ForEach(Array(serverManager.pairingPinCode), id: \.self) { digit in
+                        Text(String(digit))
+                            .font(.system(size: 40, weight: .bold, design: .rounded))
+                            .frame(width: 56, height: 72)
+                            .background(Color(.controlBackgroundColor))
+                            .cornerRadius(12)
+                    }
+                }
+                .padding(.vertical)
+
+                Text("Enter this PIN on your iPhone")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(40)
+            .background(Color(.windowBackgroundColor))
+            .cornerRadius(16)
+            .shadow(radius: 20)
+        }
     }
 
     @ViewBuilder

--- a/Projects/MacReceiver/Sources/Server/SnapServer.swift
+++ b/Projects/MacReceiver/Sources/Server/SnapServer.swift
@@ -12,6 +12,10 @@ public protocol SnapServerDelegate: AnyObject {
     func server(_ server: SnapServer, didDisconnectFrom deviceName: String)
     func server(_ server: SnapServer, didReceivePacket packet: DecodedPacket)
     func server(_ server: SnapServer, didFailWithError error: Error)
+    /// 페어링 PIN 코드 표시 요청 (새 디바이스 연결 시)
+    func server(_ server: SnapServer, showPairingPIN pin: String, forDevice deviceName: String)
+    /// 페어링 완료 (PIN 입력 완료)
+    func server(_ server: SnapServer, didCompletePairing success: Bool, deviceName: String)
 }
 
 /// Snap 서버 (macOS)
@@ -34,6 +38,16 @@ public final class SnapServer: @unchecked Sendable {
 
     public private(set) var isRunning: Bool = false
     public private(set) var connectedDeviceName: String?
+
+    // Pairing State
+    private var pendingPairingConnection: TCPConnection?
+    private var pendingPairingDeviceID: String?
+    private var pendingPairingDeviceName: String?
+    private var currentPIN: String?
+    private var trustedDevicesManager = TrustedDevicesManager.shared
+
+    /// 페어링 필수 여부 설정
+    public var requirePairing: Bool = true
 
     // MARK: - Initialization
 
@@ -180,6 +194,85 @@ public final class SnapServer: @unchecked Sendable {
             return
         }
 
+        // 페어링 확인
+        if requirePairing && !trustedDevicesManager.isTrusted(deviceID: handshake.deviceID) {
+            // 새 디바이스 - 페어링 필요
+            startPairing(handshake: handshake, connection: connection)
+            return
+        }
+
+        // 신뢰된 디바이스 - 바로 연결
+        acceptConnection(handshake: handshake, connection: connection)
+    }
+
+    private func startPairing(handshake: Handshake, connection: TCPConnection) {
+        // PIN 코드 생성
+        currentPIN = PINCodeGenerator.generate()
+        pendingPairingConnection = connection
+        pendingPairingDeviceID = handshake.deviceID
+        pendingPairingDeviceName = handshake.deviceName
+
+        // 페어링 챌린지 전송
+        let challenge = PairingChallenge(
+            deviceName: deviceName,
+            deviceID: deviceID
+        )
+        connection.send(challenge, type: .pairingChallenge)
+
+        logger.info("Pairing started for device: \(handshake.deviceName), PIN: \(self.currentPIN ?? "")")
+
+        // 델리게이트에 PIN 표시 요청
+        delegate?.server(self, showPairingPIN: currentPIN ?? "", forDevice: handshake.deviceName)
+    }
+
+    private func handlePairingResponse(_ response: PairingResponse, from connection: TCPConnection) {
+        guard connection === pendingPairingConnection,
+              let expectedPIN = currentPIN,
+              response.deviceID == pendingPairingDeviceID else {
+            // 잘못된 페어링 응답
+            let result = PairingResult(status: .rejected, message: "Invalid pairing session")
+            connection.send(result, type: .pairingResult)
+            connection.disconnect()
+            clearPairingState()
+            return
+        }
+
+        // PIN 확인
+        if response.pinCode == expectedPIN {
+            // 페어링 성공
+            trustedDevicesManager.addTrustedDevice(
+                deviceID: response.deviceID,
+                deviceName: response.deviceName
+            )
+
+            let result = PairingResult(status: .success, message: "Pairing successful")
+            connection.send(result, type: .pairingResult)
+
+            logger.info("Pairing successful for device: \(response.deviceName)")
+            delegate?.server(self, didCompletePairing: true, deviceName: response.deviceName)
+
+            // 연결 수락
+            let handshake = Handshake(
+                deviceName: response.deviceName,
+                deviceID: response.deviceID,
+                protocolVersion: UInt32(NetworkConstants.protocolVersion),
+                appVersion: "1.0.0"
+            )
+            acceptConnection(handshake: handshake, connection: connection)
+            clearPairingState()
+        } else {
+            // PIN 불일치
+            let result = PairingResult(status: .invalidPin, message: "Invalid PIN code")
+            connection.send(result, type: .pairingResult)
+            connection.disconnect()
+
+            logger.warning("Pairing failed: Invalid PIN for device: \(response.deviceName)")
+            delegate?.server(self, didCompletePairing: false, deviceName: response.deviceName)
+            clearPairingState()
+        }
+    }
+
+    private func acceptConnection(handshake: Handshake, connection: TCPConnection) {
         connectedClient = connection
         connectedDeviceName = handshake.deviceName
 
@@ -190,6 +283,27 @@ public final class SnapServer: @unchecked Sendable {
         setupHeartbeat()
 
         delegate?.server(self, didAcceptConnection: handshake.deviceName)
+    }
+
+    private func clearPairingState() {
+        currentPIN = nil
+        pendingPairingConnection = nil
+        pendingPairingDeviceID = nil
+        pendingPairingDeviceName = nil
+    }
+
+    /// 페어링 취소
+    public func cancelPairing() {
+        guard let connection = pendingPairingConnection else { return }
+
+        let result = PairingResult(status: .rejected, message: "Pairing cancelled by user")
+        connection.send(result, type: .pairingResult)
+        connection.disconnect()
+
+        if let deviceName = pendingPairingDeviceName {
+            delegate?.server(self, didCompletePairing: false, deviceName: deviceName)
+        }
+        clearPairingState()
     }
 }
 
@@ -232,6 +346,9 @@ extension SnapServer: TCPConnectionDelegate {
         switch packet {
         case .handshake(let handshake, _):
             handleHandshake(handshake, from: connection)
+
+        case .pairingResponse(let response, _):
+            handlePairingResponse(response, from: connection)
 
         case .heartbeat(let heartbeat, _):
             heartbeatManager?.didReceiveHeartbeat()

--- a/Projects/Shared/Sources/Network/MessageType.swift
+++ b/Projects/Shared/Sources/Network/MessageType.swift
@@ -50,6 +50,12 @@ public enum MessageType: UInt8, Sendable {
     case heartbeat = 0x81
     /// 연결 종료
     case disconnect = 0x82
+    /// 페어링 챌린지 (macOS → iOS: PIN 입력 요청)
+    case pairingChallenge = 0x83
+    /// 페어링 응답 (iOS → macOS: PIN 입력 결과)
+    case pairingResponse = 0x84
+    /// 페어링 결과 (macOS → iOS: 성공/실패)
+    case pairingResult = 0x85
     /// 응답 확인
     case ack = 0xFE
     /// 에러 응답

--- a/Projects/Shared/Sources/Network/PacketDecoder.swift
+++ b/Projects/Shared/Sources/Network/PacketDecoder.swift
@@ -37,6 +37,9 @@ public enum DecodedPacket: Sendable {
     case handshake(Handshake, header: PacketHeader)
     case heartbeat(Heartbeat, header: PacketHeader)
     case disconnect(Disconnect, header: PacketHeader)
+    case pairingChallenge(PairingChallenge, header: PacketHeader)
+    case pairingResponse(PairingResponse, header: PacketHeader)
+    case pairingResult(PairingResult, header: PacketHeader)
     case ack(Ack, header: PacketHeader)
     case error(SnapError, header: PacketHeader)
 
@@ -63,6 +66,9 @@ public enum DecodedPacket: Sendable {
         case .handshake: return .handshake
         case .heartbeat: return .heartbeat
         case .disconnect: return .disconnect
+        case .pairingChallenge: return .pairingChallenge
+        case .pairingResponse: return .pairingResponse
+        case .pairingResult: return .pairingResult
         case .ack: return .ack
         case .error: return .error
         }
@@ -91,6 +97,9 @@ public enum DecodedPacket: Sendable {
              .handshake(_, let header),
              .heartbeat(_, let header),
              .disconnect(_, let header),
+             .pairingChallenge(_, let header),
+             .pairingResponse(_, let header),
+             .pairingResult(_, let header),
              .ack(_, let header),
              .error(_, let header):
             return header
@@ -187,6 +196,15 @@ public enum PacketDecoder {
             case .disconnect:
                 let message = try decoder.decode(Disconnect.self, from: payload)
                 return .disconnect(message, header: header)
+            case .pairingChallenge:
+                let message = try decoder.decode(PairingChallenge.self, from: payload)
+                return .pairingChallenge(message, header: header)
+            case .pairingResponse:
+                let message = try decoder.decode(PairingResponse.self, from: payload)
+                return .pairingResponse(message, header: header)
+            case .pairingResult:
+                let message = try decoder.decode(PairingResult.self, from: payload)
+                return .pairingResult(message, header: header)
             case .ack:
                 let message = try decoder.decode(Ack.self, from: payload)
                 return .ack(message, header: header)

--- a/Projects/Shared/Sources/Protocol/SystemMessages.swift
+++ b/Projects/Shared/Sources/Protocol/SystemMessages.swift
@@ -71,3 +71,51 @@ public struct Ack: Codable, Sendable, Equatable {
 public struct Disconnect: Codable, Sendable, Equatable {
     public init() {}
 }
+
+// MARK: - Pairing
+
+/// 페어링 챌린지 (macOS → iOS)
+public struct PairingChallenge: Codable, Sendable, Equatable {
+    public var deviceName: String
+    public var deviceID: String
+
+    public init(deviceName: String = "", deviceID: String = "") {
+        self.deviceName = deviceName
+        self.deviceID = deviceID
+    }
+}
+
+/// 페어링 응답 (iOS → macOS)
+public struct PairingResponse: Codable, Sendable, Equatable {
+    public var pinCode: String
+    public var deviceName: String
+    public var deviceID: String
+
+    public init(pinCode: String = "", deviceName: String = "", deviceID: String = "") {
+        self.pinCode = pinCode
+        self.deviceName = deviceName
+        self.deviceID = deviceID
+    }
+}
+
+/// 페어링 결과 (macOS → iOS)
+public struct PairingResult: Codable, Sendable, Equatable {
+    public enum Status: Int, Codable, Sendable {
+        case success = 0
+        case invalidPin = 1
+        case timeout = 2
+        case rejected = 3
+    }
+
+    public var status: Status
+    public var message: String
+
+    public init(status: Status = .success, message: String = "") {
+        self.status = status
+        self.message = message
+    }
+
+    public var isSuccess: Bool {
+        status == .success
+    }
+}

--- a/Projects/Shared/Sources/Services/TrustedDevicesManager.swift
+++ b/Projects/Shared/Sources/Services/TrustedDevicesManager.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+/// 신뢰된 디바이스 정보
+public struct TrustedDevice: Codable, Sendable, Equatable, Identifiable {
+    public var id: String { deviceID }
+    public var deviceID: String
+    public var deviceName: String
+    public var pairedAt: Date
+
+    public init(deviceID: String, deviceName: String, pairedAt: Date = Date()) {
+        self.deviceID = deviceID
+        self.deviceName = deviceName
+        self.pairedAt = pairedAt
+    }
+}
+
+/// 신뢰된 디바이스 관리자
+public final class TrustedDevicesManager: @unchecked Sendable {
+    // MARK: - Singleton
+
+    public static let shared = TrustedDevicesManager()
+
+    // MARK: - Private Properties
+
+    private let userDefaults: UserDefaults
+    private let trustedDevicesKey = "com.snap.trustedDevices"
+    private let queue = DispatchQueue(label: "com.snap.trustedDevices", attributes: .concurrent)
+
+    // MARK: - Initialization
+
+    public init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    // MARK: - Public Methods
+
+    /// 신뢰된 디바이스 목록 조회
+    public var trustedDevices: [TrustedDevice] {
+        queue.sync {
+            loadTrustedDevices()
+        }
+    }
+
+    /// 디바이스가 신뢰되었는지 확인
+    public func isTrusted(deviceID: String) -> Bool {
+        queue.sync {
+            loadTrustedDevices().contains { $0.deviceID == deviceID }
+        }
+    }
+
+    /// 신뢰된 디바이스 추가
+    public func addTrustedDevice(_ device: TrustedDevice) {
+        queue.async(flags: .barrier) { [weak self] in
+            guard let self = self else { return }
+            var devices = self.loadTrustedDevices()
+
+            // 이미 존재하면 업데이트
+            if let index = devices.firstIndex(where: { $0.deviceID == device.deviceID }) {
+                devices[index] = device
+            } else {
+                devices.append(device)
+            }
+
+            self.saveTrustedDevices(devices)
+        }
+    }
+
+    /// 신뢰된 디바이스 추가 (ID와 이름으로)
+    public func addTrustedDevice(deviceID: String, deviceName: String) {
+        let device = TrustedDevice(deviceID: deviceID, deviceName: deviceName)
+        addTrustedDevice(device)
+    }
+
+    /// 신뢰된 디바이스 제거
+    public func removeTrustedDevice(deviceID: String) {
+        queue.async(flags: .barrier) { [weak self] in
+            guard let self = self else { return }
+            var devices = self.loadTrustedDevices()
+            devices.removeAll { $0.deviceID == deviceID }
+            self.saveTrustedDevices(devices)
+        }
+    }
+
+    /// 모든 신뢰된 디바이스 제거
+    public func removeAllTrustedDevices() {
+        queue.async(flags: .barrier) { [weak self] in
+            self?.saveTrustedDevices([])
+        }
+    }
+
+    /// 디바이스 이름으로 조회
+    public func deviceName(for deviceID: String) -> String? {
+        queue.sync {
+            loadTrustedDevices().first { $0.deviceID == deviceID }?.deviceName
+        }
+    }
+
+    // MARK: - Private Methods
+
+    private func loadTrustedDevices() -> [TrustedDevice] {
+        guard let data = userDefaults.data(forKey: trustedDevicesKey) else {
+            return []
+        }
+
+        do {
+            return try JSONDecoder().decode([TrustedDevice].self, from: data)
+        } catch {
+            return []
+        }
+    }
+
+    private func saveTrustedDevices(_ devices: [TrustedDevice]) {
+        do {
+            let data = try JSONEncoder().encode(devices)
+            userDefaults.set(data, forKey: trustedDevicesKey)
+        } catch {
+            // Silently fail
+        }
+    }
+}
+
+// MARK: - PIN Code Generator
+
+public enum PINCodeGenerator {
+    /// 4자리 랜덤 PIN 코드 생성
+    public static func generate() -> String {
+        let pin = Int.random(in: 0...9999)
+        return String(format: "%04d", pin)
+    }
+
+    /// PIN 코드 유효성 검사
+    public static func isValid(_ pin: String) -> Bool {
+        pin.count == 4 && pin.allSatisfy { $0.isNumber }
+    }
+}


### PR DESCRIPTION
## Summary
- 4자리 PIN 코드 기반 페어링 인증 시스템 구현
- 새 디바이스 연결 시 Mac에 PIN 표시, iOS에서 입력
- 인증 성공 시 신뢰된 디바이스로 저장하여 이후 자동 연결

## 주요 변경 사항
- **Shared**: 페어링 프로토콜 메시지 및 TrustedDevicesManager 추가
- **MacReceiver**: SnapServer에 페어링 플로우 및 PIN 표시 UI 추가
- **App**: ConnectionFeature에 페어링 처리 및 PIN 입력 UI 추가

## Test plan
- [ ] 새 디바이스로 연결 시 Mac에 4자리 PIN 표시 확인
- [ ] iOS에서 PIN 입력 UI 표시 확인
- [ ] 올바른 PIN 입력 시 연결 성공 확인
- [ ] 잘못된 PIN 입력 시 에러 처리 확인
- [ ] 재연결 시 PIN 입력 없이 자동 연결 확인

Close #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)