### PR TITLE
[Fix]: 앱 크래시 방지 - force cast 타입 검증 추가

### DIFF
--- a/Projects/MacReceiver/Sources/Server/WindowController.swift
+++ b/Projects/MacReceiver/Sources/Server/WindowController.swift
@@ -40,11 +40,14 @@ public final class WindowController {
             &focusedWindow
         )
 
-        guard result == .success, let window = focusedWindow else {
+        guard result == .success,
+              let window = focusedWindow,
+              CFGetTypeID(window) == AXUIElementGetTypeID() else {
             // 포커스된 윈도우가 없으면 첫 번째 윈도우 시도
             return getFirstWindow(for: appElement)
         }
 
+        // CFTypeRef를 AXUIElement로 안전하게 변환 (타입 검증 후)
         // swiftlint:disable:next force_cast
         return (window as! AXUIElement)
     }
@@ -176,17 +179,23 @@ public final class WindowController {
         AXUIElementCopyAttributeValue(window, kAXPositionAttribute as CFString, &positionValue)
         AXUIElementCopyAttributeValue(window, kAXSizeAttribute as CFString, &sizeValue)
 
-        guard let posVal = positionValue, let sizeVal = sizeValue else {
+        guard let posVal = positionValue,
+              let sizeVal = sizeValue,
+              CFGetTypeID(posVal) == AXValueGetTypeID(),
+              CFGetTypeID(sizeVal) == AXValueGetTypeID() else {
             return nil
         }
 
         var position = CGPoint.zero
         var size = CGSize.zero
 
+        // CFTypeRef를 AXValue로 안전하게 변환 (타입 검증 후)
         // swiftlint:disable force_cast
-        AXValueGetValue(posVal as! AXValue, .cgPoint, &position)
-        AXValueGetValue(sizeVal as! AXValue, .cgSize, &size)
+        let positionAXValue = posVal as! AXValue
+        let sizeAXValue = sizeVal as! AXValue
         // swiftlint:enable force_cast
+        AXValueGetValue(positionAXValue, .cgPoint, &position)
+        AXValueGetValue(sizeAXValue, .cgSize, &size)
 
         return CGRect(origin: position, size: size)
     }

--- a/Projects/Shared/Sources/Security/SecurityManager.swift
+++ b/Projects/Shared/Sources/Security/SecurityManager.swift
@@ -102,10 +102,13 @@ public final class SecurityManager: @unchecked Sendable {
         var result: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
 
-        guard status == errSecSuccess, let certificate = result else {
+        guard status == errSecSuccess,
+              let certificate = result,
+              CFGetTypeID(certificate) == SecCertificateGetTypeID() else {
             return nil
         }
 
+        // CFTypeRef를 SecCertificate로 안전하게 변환 (타입 검증 후)
         // swiftlint:disable:next force_cast
         return (certificate as! SecCertificate)
     }
@@ -168,6 +171,7 @@ public final class SecurityManager: @unchecked Sendable {
             return nil
         }
 
+        // Keychain에서 kSecClassIdentity로 쿼리했으므로 SecIdentity 타입이 보장됨
         // swiftlint:disable:next force_cast
         return (identity as! SecIdentity)
     }


### PR DESCRIPTION
## Summary
force cast (`as!`) 사용 시 타입 검증을 추가하여 런타임 크래시를 방지합니다.

## Changes
- **WindowController.swift**: AXUIElement, AXValue 캐스트 전 `CFGetTypeID()`로 타입 검증
- **SecurityManager.swift**: SecCertificate 캐스트 전 `SecCertificateGetTypeID()`로 타입 검증
- 타입이 맞지 않으면 nil 반환하여 안전하게 처리

## 점검 결과
- [x] `try!` 사용: 없음
- [x] `fatalError` 사용: 없음
- [x] 위험한 Array bounds 접근: 없음 (모두 `firstIndex(where:)` 결과 사용)
- [x] JSON 디코딩: 모두 `try?` 또는 do-catch 사용

## Test plan
- [ ] Mac Receiver 윈도우 스냅 기능 테스트
- [ ] iOS 앱 인증서 저장/로드 테스트

Close #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)