### PR TITLE
[Fix]: Swift 6 strict concurrency 설정 및 문서화

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -26,6 +26,7 @@ let project = Project(
     settings: .settings(
         base: [
             "SWIFT_VERSION": "6.0",
+            "SWIFT_STRICT_CONCURRENCY": "complete",
             "ENABLE_USER_SCRIPT_SANDBOXING": "NO",
         ],
         configurations: [

--- a/Projects/App/Sources/Services/MotionManager.swift
+++ b/Projects/App/Sources/Services/MotionManager.swift
@@ -10,6 +10,8 @@ public enum MotionEvent: Equatable, Sendable {
 }
 
 /// CoreMotion 기반 모션 매니저
+///
+/// - Note: `@unchecked Sendable` - 내부 OperationQueue(`motionQueue`)를 통해 모션 업데이트가 직렬화되어 스레드 안전함
 public final class MotionManager: @unchecked Sendable {
     // MARK: - Singleton
 

--- a/Projects/App/Sources/Services/SnapClient.swift
+++ b/Projects/App/Sources/Services/SnapClient.swift
@@ -17,6 +17,8 @@ public protocol SnapClientDelegate: AnyObject {
 }
 
 /// Snap 클라이언트 (iOS)
+///
+/// - Note: `@unchecked Sendable` - 내부 lock/queue를 통해 모든 상태 접근이 직렬화되어 스레드 안전함
 public final class SnapClient: @unchecked Sendable {
     // MARK: - Properties
 

--- a/Projects/App/Sources/Services/SpeechRecognizer.swift
+++ b/Projects/App/Sources/Services/SpeechRecognizer.swift
@@ -10,6 +10,8 @@ public enum SpeechRecognitionEvent: Equatable, Sendable {
 }
 
 /// 음성 인식 서비스
+///
+/// - Note: `@unchecked Sendable` - SFSpeechRecognizer와 AVAudioEngine은 내부적으로 스레드 안전하게 관리됨
 public final class SpeechRecognizer: @unchecked Sendable {
     // MARK: - Properties
 

--- a/Projects/MacReceiver/Sources/Server/InputSimulator.swift
+++ b/Projects/MacReceiver/Sources/Server/InputSimulator.swift
@@ -3,6 +3,8 @@ import CoreGraphics
 import Shared
 
 /// 입력 시뮬레이터 (마우스, 키보드 이벤트 주입)
+///
+/// - Note: `@unchecked Sendable` - 상태를 갖지 않고 CGEvent API만 호출하므로 스레드 안전함
 public final class InputSimulator: @unchecked Sendable {
     // MARK: - Singleton
 

--- a/Projects/MacReceiver/Sources/Server/SnapServer.swift
+++ b/Projects/MacReceiver/Sources/Server/SnapServer.swift
@@ -19,6 +19,8 @@ public protocol SnapServerDelegate: AnyObject {
 }
 
 /// Snap 서버 (macOS)
+///
+/// - Note: `@unchecked Sendable` - 네트워크 컴포넌트들이 각자 내부 큐를 통해 스레드 안전하게 동작함
 public final class SnapServer: @unchecked Sendable {
     // MARK: - Properties
 

--- a/Projects/Shared/Sources/Network/Bonjour/BonjourAdvertiser.swift
+++ b/Projects/Shared/Sources/Network/Bonjour/BonjourAdvertiser.swift
@@ -11,6 +11,8 @@ public protocol BonjourAdvertiserDelegate: AnyObject, Sendable {
 }
 
 /// Bonjour 서비스 광고자 (macOS에서 서비스 광고)
+///
+/// - Note: `@unchecked Sendable` - 내부 DispatchQueue(`queue`)를 통해 모든 상태 접근이 직렬화되어 스레드 안전함
 public final class BonjourAdvertiser: @unchecked Sendable {
     // MARK: - Properties
 

--- a/Projects/Shared/Sources/Network/Bonjour/BonjourBrowser.swift
+++ b/Projects/Shared/Sources/Network/Bonjour/BonjourBrowser.swift
@@ -28,6 +28,8 @@ public protocol BonjourBrowserDelegate: AnyObject, Sendable {
 }
 
 /// Bonjour 서비스 브라우저 (iOS에서 macOS 검색)
+///
+/// - Note: `@unchecked Sendable` - 내부 DispatchQueue(`queue`)를 통해 모든 상태 접근이 직렬화되어 스레드 안전함
 public final class BonjourBrowser: @unchecked Sendable {
     // MARK: - Properties
 

--- a/Projects/Shared/Sources/Network/Connection/HeartbeatManager.swift
+++ b/Projects/Shared/Sources/Network/Connection/HeartbeatManager.swift
@@ -7,6 +7,8 @@ public protocol HeartbeatManagerDelegate: AnyObject, Sendable {
 }
 
 /// 하트비트 관리자
+///
+/// - Note: `@unchecked Sendable` - 내부 DispatchQueue(`queue`)를 통해 모든 상태 접근이 직렬화되어 스레드 안전함
 public final class HeartbeatManager: @unchecked Sendable {
     // MARK: - Constants
 

--- a/Projects/Shared/Sources/Network/Connection/TCPConnection.swift
+++ b/Projects/Shared/Sources/Network/Connection/TCPConnection.swift
@@ -12,6 +12,8 @@ public protocol TCPConnectionDelegate: AnyObject, Sendable {
 }
 
 /// TCP 연결 (NWConnection 래퍼)
+///
+/// - Note: `@unchecked Sendable` - 내부 DispatchQueue(`queue`)를 통해 모든 상태 접근이 직렬화되어 스레드 안전함
 public final class TCPConnection: @unchecked Sendable {
     // MARK: - Properties
 

--- a/Projects/Shared/Sources/Network/Connection/TCPServer.swift
+++ b/Projects/Shared/Sources/Network/Connection/TCPServer.swift
@@ -11,6 +11,8 @@ public protocol TCPServerDelegate: AnyObject, Sendable {
 }
 
 /// TCP 서버 (macOS에서 사용)
+///
+/// - Note: `@unchecked Sendable` - 내부 DispatchQueue(`queue`)를 통해 모든 상태 접근이 직렬화되어 스레드 안전함
 public final class TCPServer: @unchecked Sendable {
     // MARK: - Properties
 

--- a/Projects/Shared/Sources/Network/Connection/UDPSocket.swift
+++ b/Projects/Shared/Sources/Network/Connection/UDPSocket.swift
@@ -12,6 +12,8 @@ public protocol UDPSocketDelegate: AnyObject, Sendable {
 }
 
 /// UDP 소켓 (양방향 통신)
+///
+/// - Note: `@unchecked Sendable` - 내부 DispatchQueue(`queue`)를 통해 모든 상태 접근이 직렬화되어 스레드 안전함
 public final class UDPSocket: @unchecked Sendable {
     // MARK: - Properties
 

--- a/Projects/Shared/Sources/Security/SecurityManager.swift
+++ b/Projects/Shared/Sources/Security/SecurityManager.swift
@@ -7,6 +7,8 @@ import os
 private let logger = Logger(subsystem: "com.snap.shared", category: "SecurityManager")
 
 /// 보안 관리자 - TLS/DTLS 인증서 관리
+///
+/// - Note: `@unchecked Sendable` - 내부 DispatchQueue(`queue`)를 통해 모든 상태 접근이 직렬화되어 스레드 안전함
 public final class SecurityManager: @unchecked Sendable {
     // MARK: - Singleton
 

--- a/Projects/Shared/Sources/Services/TrustedDevicesManager.swift
+++ b/Projects/Shared/Sources/Services/TrustedDevicesManager.swift
@@ -15,6 +15,8 @@ public struct TrustedDevice: Codable, Sendable, Equatable, Identifiable {
 }
 
 /// 신뢰된 디바이스 관리자
+///
+/// - Note: `@unchecked Sendable` - 내부 DispatchQueue(`queue`)를 통해 barrier를 사용한 reader-writer 패턴으로 스레드 안전함
 public final class TrustedDevicesManager: @unchecked Sendable {
     // MARK: - Singleton
 


### PR DESCRIPTION
## Summary
- Swift 6 strict concurrency 검사 활성화 (`SWIFT_STRICT_CONCURRENCY = complete`)
- `@unchecked Sendable` 사용 클래스에 스레드 안전성 문서화
- 빌드 시 concurrency 경고 0건 확인

## Changes
### Project.swift
- `SWIFT_STRICT_CONCURRENCY: "complete"` 설정 추가

### 문서화된 클래스들 (14개 파일)
| 클래스 | 스레드 안전성 패턴 |
|--------|-------------------|
| TCPServer | DispatchQueue 직렬화 |
| TCPConnection | DispatchQueue 직렬화 |
| UDPSocket | DispatchQueue 직렬화 |
| HeartbeatManager | DispatchQueue 직렬화 |
| BonjourAdvertiser | DispatchQueue 직렬화 |
| BonjourBrowser | DispatchQueue 직렬화 |
| SecurityManager | DispatchQueue 직렬화 |
| TrustedDevicesManager | Reader-Writer 배리어 패턴 |
| SnapClient | 내부 lock/queue 직렬화 |
| MotionManager | OperationQueue 직렬화 |
| SpeechRecognizer | 내부 스레드 안전 API |
| InputSimulator | 상태 없음 (stateless) |
| SnapServer | 네트워크 컴포넌트 내부 큐 |

## Test plan
- [x] `tuist build App` 빌드 성공
- [x] `tuist build MacReceiver` 빌드 성공
- [x] Concurrency 경고 0건 확인

Close #105
Close #122
Close #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)