### PR TITLE
[Feat]: Mac Receiver 로그인 시 자동 시작 옵션 추가

### DIFF
--- a/Projects/MacReceiver/Sources/MacReceiverApp.swift
+++ b/Projects/MacReceiver/Sources/MacReceiverApp.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Shared
+import ServiceManagement
 
 @main
 struct MacReceiverApp: App {
@@ -248,9 +249,17 @@ struct SettingsView: View {
 struct GeneralSettingsView: View {
     @ObservedObject var serverManager: ServerManager
     @ObservedObject private var accessibilityManager = AccessibilityManager.shared
+    @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
 
     var body: some View {
         Form {
+            Section("시작") {
+                Toggle("로그인 시 자동 시작", isOn: $launchAtLogin)
+                    .onChange(of: launchAtLogin) { _, newValue in
+                        setLaunchAtLogin(newValue)
+                    }
+            }
+
             Section {
                 LabeledContent("서버 상태") {
                     Text(serverManager.isRunning ? "실행 중" : "중지됨")
@@ -300,6 +309,20 @@ struct GeneralSettingsView: View {
         .padding()
         .onAppear {
             accessibilityManager.checkAccessibility()
+            launchAtLogin = SMAppService.mainApp.status == .enabled
+        }
+    }
+
+    private func setLaunchAtLogin(_ enabled: Bool) {
+        do {
+            if enabled {
+                try SMAppService.mainApp.register()
+            } else {
+                try SMAppService.mainApp.unregister()
+            }
+        } catch {
+            // 실패 시 상태 롤백
+            launchAtLogin = SMAppService.mainApp.status == .enabled
         }
     }
 }


### PR DESCRIPTION
## Summary
- SMAppService를 사용하여 로그인 시 자동 시작 기능 구현
- 설정 화면에 "로그인 시 자동 시작" 토글 추가

## Changes
- `MacReceiverApp.swift`: GeneralSettingsView에 토글 추가 및 SMAppService 연동

## Test plan
- [x] MacReceiver 빌드 성공
- [ ] 토글 ON/OFF 시 로그인 아이템 등록/해제 확인
- [ ] 재부팅 후 자동 시작 확인

Close #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)