### PR TITLE
[Fix]: 다크모드/라이트모드 전환 시 색상 깜빡임 수정

### DIFF
--- a/Projects/App/Sources/DesignSystem/SnapColors.swift
+++ b/Projects/App/Sources/DesignSystem/SnapColors.swift
@@ -49,6 +49,32 @@ public enum SnapColors {
     /// 비활성화된 텍스트
     public static let textDisabled = Color(white: 0.3)
 
+    // MARK: - System Color Aliases (시스템 색상 대체용)
+
+    /// systemBackground 대체
+    public static let systemBackground = background
+
+    /// secondarySystemBackground 대체
+    public static let secondarySystemBackground = backgroundElevated
+
+    /// tertiarySystemBackground 대체
+    public static let tertiarySystemBackground = backgroundTertiary
+
+    /// tertiarySystemFill 대체
+    public static let tertiarySystemFill = backgroundHighlight
+
+    /// label 대체
+    public static let label = textPrimary
+
+    /// secondaryLabel 대체
+    public static let secondaryLabel = textSecondary
+
+    /// tertiaryLabel 대체
+    public static let tertiaryLabel = textTertiary
+
+    /// separator 대체
+    public static let separator = Color(white: 0.2)
+
     // MARK: - Border & Divider
 
     /// 기본 테두리

--- a/Projects/App/Sources/Features/Keyboard/KeyboardView.swift
+++ b/Projects/App/Sources/Features/Keyboard/KeyboardView.swift
@@ -29,7 +29,7 @@ public struct KeyboardView: View {
             arrowKeys
                 .padding()
         }
-        .background(Color(.systemBackground))
+        .background(SnapColors.systemBackground)
     }
 
     // MARK: - Text Input Area
@@ -40,13 +40,13 @@ public struct KeyboardView: View {
                 .textFieldStyle(.plain)
                 .font(.body)
                 .padding()
-                .background(Color(.secondarySystemBackground))
+                .background(SnapColors.secondarySystemBackground)
                 .clipShape(RoundedRectangle(cornerRadius: 12))
                 .overlay(
                     RoundedRectangle(cornerRadius: 12)
-                        .strokeBorder(Color(.separator), lineWidth: 1)
+                        .strokeBorder(SnapColors.separator, lineWidth: 1)
                 )
-                .foregroundStyle(Color(.label))
+                .foregroundStyle(SnapColors.label)
                 .focused($isTextFieldFocused)
                 .accessibilityLabel("텍스트 입력")
                 .accessibilityHint("Mac으로 보낼 텍스트를 입력하세요")
@@ -56,7 +56,7 @@ public struct KeyboardView: View {
             } label: {
                 Image(systemName: "xmark.circle.fill")
                     .font(.title2)
-                    .foregroundStyle(Color(.tertiaryLabel))
+                    .foregroundStyle(SnapColors.tertiaryLabel)
             }
             .opacity(store.inputText.isEmpty ? 0 : 1)
             .accessibilityLabel("텍스트 지우기")
@@ -141,14 +141,14 @@ public struct KeyboardView: View {
             } label: {
                 Text("Space")
                     .font(.subheadline.weight(.medium))
-                    .foregroundStyle(Color(.label))
+                    .foregroundStyle(SnapColors.label)
                     .frame(maxWidth: .infinity)
                     .frame(height: 44)
-                    .background(Color(.secondarySystemBackground))
+                    .background(SnapColors.secondarySystemBackground)
                     .clipShape(RoundedRectangle(cornerRadius: 12))
                     .overlay(
                         RoundedRectangle(cornerRadius: 12)
-                            .strokeBorder(Color(.separator), lineWidth: 1)
+                            .strokeBorder(SnapColors.separator, lineWidth: 1)
                     )
             }
             .buttonStyle(.plain)
@@ -241,25 +241,25 @@ struct ModifierKeyButton: View {
     }
 
     private var foregroundColor: Color {
-        isActive ? Color(.label) : Color(.secondaryLabel)
+        isActive ? SnapColors.label : SnapColors.secondaryLabel
     }
 
     private var backgroundColor: Color {
         if isLocked {
             return Color.accentColor.opacity(0.2)
         } else if isActive {
-            return Color(.tertiarySystemBackground)
+            return SnapColors.tertiarySystemBackground
         }
-        return Color(.secondarySystemBackground)
+        return SnapColors.secondarySystemBackground
     }
 
     private var borderColor: Color {
         if isLocked {
             return .accentColor
         } else if isActive {
-            return Color(.separator)
+            return SnapColors.separator
         }
-        return Color(.separator).opacity(0.5)
+        return SnapColors.separator.opacity(0.5)
     }
 }
 
@@ -281,14 +281,14 @@ struct SpecialKeyButton: View {
                 Text(label)
                     .font(.caption2.weight(.medium))
             }
-            .foregroundStyle(Color(.label))
+            .foregroundStyle(SnapColors.label)
             .frame(maxWidth: .infinity)
             .frame(height: 56)
-            .background(isPressed ? Color(.tertiarySystemFill) : Color(.secondarySystemBackground))
+            .background(isPressed ? SnapColors.tertiarySystemFill : SnapColors.secondarySystemBackground)
             .clipShape(RoundedRectangle(cornerRadius: 12))
             .overlay(
                 RoundedRectangle(cornerRadius: 12)
-                    .strokeBorder(Color(.separator), lineWidth: 1)
+                    .strokeBorder(SnapColors.separator, lineWidth: 1)
             )
             .scaleEffect(isPressed ? 0.95 : 1.0)
         }
@@ -336,13 +336,13 @@ struct ArrowKeyButton: View {
         Button(action: action) {
             Image(systemName: iconName)
                 .font(.title3.weight(.semibold))
-                .foregroundStyle(Color(.label))
+                .foregroundStyle(SnapColors.label)
                 .frame(width: 56, height: 44)
-                .background(isPressed ? Color(.tertiarySystemFill) : Color(.secondarySystemBackground))
+                .background(isPressed ? SnapColors.tertiarySystemFill : SnapColors.secondarySystemBackground)
                 .clipShape(RoundedRectangle(cornerRadius: 8))
                 .overlay(
                     RoundedRectangle(cornerRadius: 8)
-                        .strokeBorder(Color(.separator), lineWidth: 1)
+                        .strokeBorder(SnapColors.separator, lineWidth: 1)
                 )
                 .scaleEffect(isPressed ? 0.95 : 1.0)
         }

--- a/Projects/App/Sources/Features/LaserPointer/LaserPointerView.swift
+++ b/Projects/App/Sources/Features/LaserPointer/LaserPointerView.swift
@@ -48,7 +48,7 @@ public struct LaserPointerView: View {
             if store.isActive && store.isCalibrated {
                 Text("기기를 움직여 커서를 이동하세요")
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(SnapColors.textSecondary)
             }
         }
     }
@@ -111,7 +111,7 @@ public struct LaserPointerView: View {
             HStack {
                 Text("감도")
                     .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(SnapColors.textSecondary)
 
                 Spacer()
 
@@ -132,7 +132,7 @@ public struct LaserPointerView: View {
             .tint(SnapColors.laserPointer)
         }
         .padding()
-        .background(Color(.secondarySystemBackground))
+        .background(SnapColors.secondarySystemBackground)
         .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 
@@ -195,7 +195,7 @@ public struct LaserPointerSection: View {
 
                             Text("기기를 움직여 커서 제어")
                                 .font(.subheadline)
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(SnapColors.textSecondary)
 
                             // 캘리브레이션 버튼
                             Button {
@@ -213,7 +213,7 @@ public struct LaserPointerSection: View {
                     // 감도 슬라이더
                     HStack {
                         Image(systemName: "tortoise")
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(SnapColors.textSecondary)
 
                         Slider(
                             value: Binding(
@@ -225,7 +225,7 @@ public struct LaserPointerSection: View {
                         .tint(SnapColors.laserPointer)
 
                         Image(systemName: "hare")
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(SnapColors.textSecondary)
                     }
                 }
             } else {
@@ -241,13 +241,13 @@ public struct LaserPointerSection: View {
                             .fontWeight(.medium)
                         Text("iPhone을 허공에 움직여 Mac 커서를 제어합니다")
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(SnapColors.textSecondary)
                     }
 
                     Spacer()
                 }
                 .padding()
-                .background(Color(.tertiarySystemBackground))
+                .background(SnapColors.tertiarySystemBackground)
                 .clipShape(RoundedRectangle(cornerRadius: 12))
             }
         }

--- a/Projects/App/Sources/Features/Macro/MacroEditorView.swift
+++ b/Projects/App/Sources/Features/Macro/MacroEditorView.swift
@@ -230,7 +230,7 @@ struct IconPickerView: View {
                         .frame(width: 44, height: 44)
                         .background(
                             RoundedRectangle(cornerRadius: 8)
-                                .fill(selectedIcon == icon ? color : Color(.tertiarySystemBackground))
+                                .fill(selectedIcon == icon ? color : SnapColors.tertiarySystemBackground)
                         )
                 }
                 .buttonStyle(.plain)
@@ -319,7 +319,7 @@ struct KeyComboPickerView: View {
                     Spacer()
 
                     Text(keyDisplayName)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(SnapColors.textSecondary)
 
                     Image(systemName: "chevron.right")
                         .font(.caption)
@@ -343,13 +343,13 @@ struct KeyComboPickerView: View {
                 HStack {
                     Text("단축키:")
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(SnapColors.textSecondary)
 
                     Text(fullComboDisplayName)
                         .font(.caption.monospaced())
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
-                        .background(Color(.tertiarySystemBackground))
+                        .background(SnapColors.tertiarySystemBackground)
                         .clipShape(RoundedRectangle(cornerRadius: 4))
                 }
             }
@@ -407,7 +407,7 @@ struct ModifierToggle: View {
                 .frame(width: 44, height: 44)
                 .background(
                     RoundedRectangle(cornerRadius: 8)
-                        .fill(isSelected ? Color.accentColor : Color(.tertiarySystemBackground))
+                        .fill(isSelected ? Color.accentColor : SnapColors.tertiarySystemBackground)
                 )
                 .foregroundStyle(isSelected ? .white : .primary)
         }

--- a/Projects/App/Sources/Features/Macro/MacroView.swift
+++ b/Projects/App/Sources/Features/Macro/MacroView.swift
@@ -29,7 +29,7 @@ public struct MacroView: View {
             }
             .padding(.vertical)
         }
-        .background(Color(.systemBackground))
+        .background(SnapColors.systemBackground)
     }
 
     // MARK: - Header
@@ -115,22 +115,22 @@ struct AddMacroButton: View {
             VStack(spacing: 8) {
                 Image(systemName: "plus")
                     .font(.system(size: 24, weight: .medium))
-                    .foregroundStyle(Color(.secondaryLabel))
+                    .foregroundStyle(SnapColors.secondaryLabel)
 
                 Text("추가")
                     .font(.caption2)
                     .fontWeight(.medium)
-                    .foregroundStyle(Color(.tertiaryLabel))
+                    .foregroundStyle(SnapColors.tertiaryLabel)
             }
             .frame(maxWidth: .infinity)
             .frame(height: 80)
             .background(
                 RoundedRectangle(cornerRadius: 16)
-                    .fill(Color(.tertiarySystemBackground))
+                    .fill(SnapColors.tertiarySystemBackground)
                     .overlay(
                         RoundedRectangle(cornerRadius: 16)
                             .strokeBorder(
-                                Color(.separator),
+                                SnapColors.separator,
                                 style: StrokeStyle(lineWidth: 2, dash: [8, 4])
                             )
                     )
@@ -370,7 +370,7 @@ public struct MacroPadSection: View {
             }
         }
         .padding()
-        .background(Color(.secondarySystemBackground).opacity(0.5))
+        .background(SnapColors.secondarySystemBackground.opacity(0.5))
         .clipShape(RoundedRectangle(cornerRadius: 16))
         .sheet(isPresented: Binding(
             get: { store.editorState != nil },

--- a/Projects/App/Sources/Features/Media/MediaView.swift
+++ b/Projects/App/Sources/Features/Media/MediaView.swift
@@ -30,7 +30,7 @@ public struct MediaView: View {
             Spacer()
         }
         .padding()
-        .background(Color(.systemBackground))
+        .background(SnapColors.systemBackground)
         .onAppear {
             if store.isHardwareVolumeControlEnabled {
                 setupVolumeHandler()
@@ -76,7 +76,7 @@ public struct MediaView: View {
     private var albumArtView: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 16)
-                .fill(Color(.secondarySystemBackground))
+                .fill(SnapColors.secondarySystemBackground)
 
             if let artworkData = store.nowPlayingInfo.artworkData,
                let uiImage = UIImage(data: artworkData) {
@@ -112,7 +112,7 @@ public struct MediaView: View {
         case "spotify":
             return .green
         default:
-            return Color(.tertiaryLabel)
+            return SnapColors.tertiaryLabel
         }
     }
 
@@ -123,11 +123,11 @@ public struct MediaView: View {
             VStack(spacing: 8) {
                 Text("Not Playing")
                     .font(.title3.weight(.semibold))
-                    .foregroundStyle(Color(.label))
+                    .foregroundStyle(SnapColors.label)
 
                 Text("Play music on your Mac")
                     .font(.subheadline)
-                    .foregroundStyle(Color(.secondaryLabel))
+                    .foregroundStyle(SnapColors.secondaryLabel)
             }
         } else {
             // Now Playing Info
@@ -140,20 +140,20 @@ public struct MediaView: View {
 
                     Text(store.nowPlayingInfo.appName)
                         .font(.caption.weight(.medium))
-                        .foregroundStyle(Color(.secondaryLabel))
+                        .foregroundStyle(SnapColors.secondaryLabel)
                 }
 
                 // Track Title
                 Text(store.nowPlayingInfo.title)
                     .font(.title3.weight(.semibold))
-                    .foregroundStyle(Color(.label))
+                    .foregroundStyle(SnapColors.label)
                     .lineLimit(1)
                     .truncationMode(.tail)
 
                 // Artist
                 Text(store.nowPlayingInfo.artist)
                     .font(.subheadline)
-                    .foregroundStyle(Color(.secondaryLabel))
+                    .foregroundStyle(SnapColors.secondaryLabel)
                     .lineLimit(1)
                     .truncationMode(.tail)
 
@@ -161,7 +161,7 @@ public struct MediaView: View {
                 if !store.nowPlayingInfo.album.isEmpty {
                     Text(store.nowPlayingInfo.album)
                         .font(.caption)
-                        .foregroundStyle(Color(.tertiaryLabel))
+                        .foregroundStyle(SnapColors.tertiaryLabel)
                         .lineLimit(1)
                         .truncationMode(.tail)
                 }
@@ -215,7 +215,7 @@ public struct MediaView: View {
                 } label: {
                     Image(systemName: "speaker.fill")
                         .font(.callout)
-                        .foregroundStyle(Color(.secondaryLabel))
+                        .foregroundStyle(SnapColors.secondaryLabel)
                 }
                 .accessibilityLabel("볼륨 줄이기")
 
@@ -234,7 +234,7 @@ public struct MediaView: View {
                 } label: {
                     Image(systemName: "speaker.wave.3.fill")
                         .font(.callout)
-                        .foregroundStyle(Color(.secondaryLabel))
+                        .foregroundStyle(SnapColors.secondaryLabel)
                 }
                 .accessibilityLabel("볼륨 높이기")
             }
@@ -251,14 +251,14 @@ public struct MediaView: View {
                     Text(store.isMuted ? "Unmute" : "Mute")
                         .font(.subheadline.weight(.medium))
                 }
-                .foregroundStyle(store.isMuted ? .red : Color(.secondaryLabel))
+                .foregroundStyle(store.isMuted ? .red : SnapColors.secondaryLabel)
                 .padding(.horizontal, 24)
                 .padding(.vertical, 12)
-                .background(Color(.secondarySystemBackground))
+                .background(SnapColors.secondarySystemBackground)
                 .clipShape(Capsule())
                 .overlay(
                     Capsule()
-                        .strokeBorder(Color(.separator), lineWidth: 1)
+                        .strokeBorder(SnapColors.separator, lineWidth: 1)
                 )
             }
             .accessibilityLabel(store.isMuted ? "음소거 해제" : "음소거")
@@ -272,24 +272,24 @@ public struct MediaView: View {
             HStack(spacing: 12) {
                 Image(systemName: "iphone.radiowaves.left.and.right")
                     .font(.body)
-                    .foregroundStyle(Color(.secondaryLabel))
+                    .foregroundStyle(SnapColors.secondaryLabel)
                     .frame(width: 24)
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Hardware Volume Buttons")
                         .font(.subheadline.weight(.medium))
-                        .foregroundStyle(Color(.label))
+                        .foregroundStyle(SnapColors.label)
 
                     Text("Use iPhone volume buttons to control Mac")
                         .font(.caption)
-                        .foregroundStyle(Color(.tertiaryLabel))
+                        .foregroundStyle(SnapColors.tertiaryLabel)
                 }
             }
         }
         .toggleStyle(.switch)
         .padding(.horizontal)
         .padding(.vertical, 12)
-        .background(Color(.secondarySystemBackground))
+        .background(SnapColors.secondarySystemBackground)
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .padding(.horizontal)
         .accessibilityLabel("하드웨어 볼륨 버튼 사용")
@@ -311,13 +311,13 @@ struct MediaButton: View {
         Button(action: action) {
             Image(systemName: icon)
                 .font(.system(size: size, weight: .medium))
-                .foregroundStyle(Color(.label))
+                .foregroundStyle(SnapColors.label)
                 .frame(width: buttonSize, height: buttonSize)
                 .background(backgroundColor)
                 .clipShape(Circle())
                 .overlay(
                     Circle()
-                        .strokeBorder(Color(.separator), lineWidth: 1)
+                        .strokeBorder(SnapColors.separator, lineWidth: 1)
                 )
                 .scaleEffect(isPressed ? 0.9 : 1.0)
         }
@@ -339,7 +339,7 @@ struct MediaButton: View {
     }
 
     private var backgroundColor: Color {
-        isPrimary ? Color(.tertiarySystemBackground) : Color(.secondarySystemBackground)
+        isPrimary ? SnapColors.tertiarySystemBackground : SnapColors.secondarySystemBackground
     }
 }
 

--- a/Projects/App/Sources/Features/Presenter/PresenterView.swift
+++ b/Projects/App/Sources/Features/Presenter/PresenterView.swift
@@ -26,10 +26,10 @@ public struct PresenterSection: View {
                 if store.isPresenting {
                     Text("Slide \(store.slideNumber)")
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(SnapColors.textSecondary)
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
-                        .background(Color(.tertiarySystemBackground))
+                        .background(SnapColors.tertiarySystemBackground)
                         .clipShape(Capsule())
                 }
             }
@@ -43,7 +43,7 @@ public struct PresenterSection: View {
             }
         }
         .padding()
-        .background(Color(.secondarySystemBackground).opacity(0.5))
+        .background(SnapColors.secondarySystemBackground.opacity(0.5))
         .clipShape(RoundedRectangle(cornerRadius: 16))
         .onChange(of: store.isOvertime) { _, isOvertime in
             if isOvertime {
@@ -61,7 +61,7 @@ public struct PresenterSection: View {
             HStack {
                 Text("타이머 모드")
                     .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(SnapColors.textSecondary)
 
                 Spacer()
 
@@ -79,7 +79,7 @@ public struct PresenterSection: View {
                 HStack {
                     Text("목표 시간")
                         .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(SnapColors.textSecondary)
 
                     Spacer()
 
@@ -141,7 +141,7 @@ public struct PresenterSection: View {
                 GeometryReader { geometry in
                     ZStack(alignment: .leading) {
                         RoundedRectangle(cornerRadius: 4)
-                            .fill(Color(.tertiarySystemBackground))
+                            .fill(SnapColors.tertiarySystemBackground)
                             .frame(height: 8)
 
                         RoundedRectangle(cornerRadius: 4)
@@ -160,7 +160,7 @@ public struct PresenterSection: View {
             }
         }
         .padding()
-        .background(Color(.tertiarySystemBackground))
+        .background(SnapColors.tertiarySystemBackground)
         .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 
@@ -271,12 +271,12 @@ struct SlideButton: View {
 
                 Text(label)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(SnapColors.textSecondary)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(
                 RoundedRectangle(cornerRadius: 16)
-                    .fill(Color(.tertiarySystemBackground))
+                    .fill(SnapColors.tertiarySystemBackground)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 16)
@@ -320,7 +320,7 @@ struct ControlButton: View {
 
                 Text(label)
                     .font(.caption2)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(SnapColors.textSecondary)
             }
             .frame(maxWidth: .infinity)
             .frame(height: 60)
@@ -343,12 +343,12 @@ struct ControlButton: View {
 
     private var backgroundColor: Color {
         if isActive { return Color.accentColor.opacity(0.15) }
-        return Color(.tertiarySystemBackground)
+        return SnapColors.tertiarySystemBackground
     }
 
     private var borderColor: Color {
         if isActive { return Color.accentColor.opacity(0.3) }
-        return Color(.separator)
+        return SnapColors.separator
     }
 }
 

--- a/Projects/App/Sources/Features/QuickLaunch/QuickLaunchView.swift
+++ b/Projects/App/Sources/Features/QuickLaunch/QuickLaunchView.swift
@@ -27,7 +27,7 @@ public struct QuickLaunchView: View {
             }
             .padding(.vertical)
         }
-        .background(Color(.systemBackground))
+        .background(SnapColors.systemBackground)
         .sheet(isPresented: Binding(
             get: { store.editorState != nil },
             set: { if !$0 { store.send(.dismissEditor) } }
@@ -194,22 +194,22 @@ struct AddQuickLaunchButton: View {
             VStack(spacing: 8) {
                 Image(systemName: "plus")
                     .font(.system(size: 24, weight: .medium))
-                    .foregroundStyle(Color(.secondaryLabel))
+                    .foregroundStyle(SnapColors.secondaryLabel)
 
                 Text("추가")
                     .font(.caption2)
                     .fontWeight(.medium)
-                    .foregroundStyle(Color(.tertiaryLabel))
+                    .foregroundStyle(SnapColors.tertiaryLabel)
             }
             .frame(maxWidth: .infinity)
             .frame(height: 80)
             .background(
                 RoundedRectangle(cornerRadius: 16)
-                    .fill(Color(.tertiarySystemBackground))
+                    .fill(SnapColors.tertiarySystemBackground)
                     .overlay(
                         RoundedRectangle(cornerRadius: 16)
                             .strokeBorder(
-                                Color(.separator),
+                                SnapColors.separator,
                                 style: StrokeStyle(lineWidth: 2, dash: [8, 4])
                             )
                     )
@@ -339,7 +339,7 @@ struct QuickLaunchIconPicker: View {
                             RoundedRectangle(cornerRadius: 8)
                                 .fill(selectedIcon == icon
                                       ? Color.accentColor.opacity(0.2)
-                                      : Color(.tertiarySystemBackground))
+                                      : SnapColors.tertiarySystemBackground)
                         )
                         .foregroundStyle(selectedIcon == icon ? Color.accentColor : .primary)
                         .overlay(
@@ -377,7 +377,7 @@ struct QuickLaunchColorPicker: View {
                         )
                         .overlay(
                             Circle()
-                                .strokeBorder(Color(.separator), lineWidth: 1)
+                                .strokeBorder(SnapColors.separator, lineWidth: 1)
                         )
                         .shadow(color: color.color.opacity(0.3), radius: 4, y: 2)
                 }
@@ -455,7 +455,7 @@ public struct QuickLaunchSection: View {
             }
         }
         .padding()
-        .background(Color(.secondarySystemBackground).opacity(0.5))
+        .background(SnapColors.secondarySystemBackground.opacity(0.5))
         .clipShape(RoundedRectangle(cornerRadius: 16))
         .sheet(isPresented: Binding(
             get: { store.editorState != nil },

--- a/Projects/App/Sources/Features/Settings/SettingsView.swift
+++ b/Projects/App/Sources/Features/Settings/SettingsView.swift
@@ -53,7 +53,7 @@ public struct SettingsView: View {
                     Text("트랙패드 감도")
                     Spacer()
                     Text(String(format: "%.1f", store.trackpadSensitivity))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(SnapColors.textSecondary)
                         .monospacedDigit()
                 }
                 Slider(
@@ -71,7 +71,7 @@ public struct SettingsView: View {
                     Text("스크롤 감도")
                     Spacer()
                     Text(String(format: "%.1f", store.scrollSensitivity))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(SnapColors.textSecondary)
                         .monospacedDigit()
                 }
                 Slider(
@@ -89,7 +89,7 @@ public struct SettingsView: View {
                     Text("레이저 포인터 감도")
                     Spacer()
                     Text(String(format: "%.1f", store.laserSensitivity))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(SnapColors.textSecondary)
                         .monospacedDigit()
                 }
                 Slider(

--- a/Projects/App/Sources/Features/ShortsRemote/ShortsRemoteView.swift
+++ b/Projects/App/Sources/Features/ShortsRemote/ShortsRemoteView.swift
@@ -21,7 +21,7 @@ public struct ShortsRemoteView: View {
             controlButtons
         }
         .padding()
-        .background(Color(.systemBackground))
+        .background(SnapColors.systemBackground)
     }
 
     // MARK: - Platform Picker
@@ -109,7 +109,7 @@ struct PlatformButton: View {
             .padding(.vertical, 12)
             .background(
                 RoundedRectangle(cornerRadius: 12)
-                    .fill(isSelected ? platformColor.opacity(0.15) : Color(.tertiarySystemBackground))
+                    .fill(isSelected ? platformColor.opacity(0.15) : SnapColors.tertiarySystemBackground)
             )
             .foregroundStyle(isSelected ? platformColor : .secondary)
             .overlay(
@@ -146,10 +146,10 @@ struct SwipeNavigationArea: View {
             ZStack {
                 // Background
                 RoundedRectangle(cornerRadius: 24)
-                    .fill(Color(.secondarySystemBackground))
+                    .fill(SnapColors.secondarySystemBackground)
                     .overlay(
                         RoundedRectangle(cornerRadius: 24)
-                            .strokeBorder(Color(.separator), lineWidth: 1)
+                            .strokeBorder(SnapColors.separator, lineWidth: 1)
                     )
 
                 // Content
@@ -172,11 +172,11 @@ struct SwipeNavigationArea: View {
                     VStack(spacing: 12) {
                         Image(systemName: "hand.draw.fill")
                             .font(.system(size: 48))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(SnapColors.textSecondary)
 
                         Text("위아래로 스와이프")
                             .font(.subheadline)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(SnapColors.textSecondary)
                     }
                     .offset(y: offset * 0.3)
 
@@ -258,7 +258,7 @@ struct ShortsControlButton: View {
             .frame(width: isLarge ? 80 : 60, height: isLarge ? 80 : 60)
             .background(
                 RoundedRectangle(cornerRadius: 16)
-                    .fill(Color(.tertiarySystemBackground))
+                    .fill(SnapColors.tertiarySystemBackground)
             )
             .foregroundStyle(.primary)
         }
@@ -336,7 +336,7 @@ public struct ShortsRemoteSection: View {
             }
         }
         .padding()
-        .background(Color(.secondarySystemBackground).opacity(0.5))
+        .background(SnapColors.secondarySystemBackground.opacity(0.5))
         .clipShape(RoundedRectangle(cornerRadius: 16))
     }
 }
@@ -362,7 +362,7 @@ struct PlatformChip: View {
             .padding(.vertical, 8)
             .background(
                 Capsule()
-                    .fill(isSelected ? platformColor.opacity(0.15) : Color(.tertiarySystemBackground))
+                    .fill(isSelected ? platformColor.opacity(0.15) : SnapColors.tertiarySystemBackground)
             )
             .foregroundStyle(isSelected ? platformColor : .secondary)
         }
@@ -391,7 +391,7 @@ struct CompactSwipeArea: View {
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 16)
-                .fill(Color(.tertiarySystemBackground))
+                .fill(SnapColors.tertiarySystemBackground)
 
             HStack {
                 // Up/Previous
@@ -415,7 +415,7 @@ struct CompactSwipeArea: View {
                         .font(.caption2)
                 }
                 .frame(maxWidth: .infinity)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(SnapColors.textSecondary)
 
                 Divider()
                     .frame(height: 40)
@@ -476,7 +476,7 @@ struct CompactControlButton: View {
                 .frame(width: 48, height: 48)
                 .background(
                     RoundedRectangle(cornerRadius: 12)
-                        .fill(isHighlighted ? Color.accentColor.opacity(0.15) : Color(.tertiarySystemBackground))
+                        .fill(isHighlighted ? Color.accentColor.opacity(0.15) : SnapColors.tertiarySystemBackground)
                 )
                 .foregroundStyle(isHighlighted ? Color.accentColor : .primary)
         }

--- a/Projects/App/Sources/Features/Trackpad/TrackpadView.swift
+++ b/Projects/App/Sources/Features/Trackpad/TrackpadView.swift
@@ -538,10 +538,10 @@ struct LaserControlArea: View {
         ZStack {
             // Background
             RoundedRectangle(cornerRadius: 24)
-                .fill(Color(.secondarySystemBackground))
+                .fill(SnapColors.secondarySystemBackground)
                 .overlay(
                     RoundedRectangle(cornerRadius: 24)
-                        .strokeBorder(Color(.separator), lineWidth: 1)
+                        .strokeBorder(SnapColors.separator, lineWidth: 1)
                 )
 
             VStack(spacing: 12) {
@@ -562,7 +562,7 @@ struct LaserControlArea: View {
                     }
                 }
                 .padding(3)
-                .background(Color(.tertiarySystemBackground))
+                .background(SnapColors.tertiarySystemBackground)
                 .clipShape(Capsule())
                 .padding(.horizontal)
 
@@ -589,12 +589,12 @@ struct LaserControlArea: View {
 
                     // Main button
                     Circle()
-                        .fill(isActive ? SnapColors.laserPointer : Color(.tertiarySystemBackground))
+                        .fill(isActive ? SnapColors.laserPointer : SnapColors.tertiarySystemBackground)
                         .frame(width: 160, height: 160)
                         .overlay(
                             Circle()
                                 .strokeBorder(
-                                    isActive ? SnapColors.laserPointer.opacity(0.6) : Color(.separator),
+                                    isActive ? SnapColors.laserPointer.opacity(0.6) : SnapColors.separator,
                                     lineWidth: 2
                                 )
                         )
@@ -608,7 +608,7 @@ struct LaserControlArea: View {
 
                         Text(buttonLabel(isActive: isActive, mode: activationMode))
                             .font(.caption.weight(.bold))
-                            .foregroundStyle(isActive ? .white : Color(.secondaryLabel))
+                            .foregroundStyle(isActive ? .white : SnapColors.secondaryLabel)
                             .tracking(1)
                     }
                 }
@@ -642,7 +642,7 @@ struct LaserControlArea: View {
                 // Sensitivity (compact)
                 HStack(spacing: 8) {
                     Image(systemName: "tortoise")
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(SnapColors.textSecondary)
                         .font(.caption2)
 
                     Slider(
@@ -655,12 +655,12 @@ struct LaserControlArea: View {
                     .tint(SnapColors.laserPointer)
 
                     Image(systemName: "hare")
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(SnapColors.textSecondary)
                         .font(.caption2)
 
                     Text("\(Int(store.laserPointer.sensitivity))")
                         .font(.caption2.monospacedDigit())
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(SnapColors.textSecondary)
                         .frame(width: 24)
                 }
                 .padding(.horizontal)
@@ -752,19 +752,19 @@ struct LaserClickButton: View {
         VStack(spacing: 8) {
             Image(systemName: icon)
                 .font(.title2)
-                .foregroundStyle(isPressed ? Color(.label) : color)
+                .foregroundStyle(isPressed ? SnapColors.label : color)
 
             Text(label)
                 .font(.caption.weight(.semibold))
-                .foregroundStyle(Color(.secondaryLabel))
+                .foregroundStyle(SnapColors.secondaryLabel)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(
             RoundedRectangle(cornerRadius: 16)
-                .fill(isPressed ? Color(.tertiarySystemFill) : Color(.secondarySystemBackground))
+                .fill(isPressed ? SnapColors.tertiarySystemFill : SnapColors.secondarySystemBackground)
                 .overlay(
                     RoundedRectangle(cornerRadius: 16)
-                        .strokeBorder(Color(.separator), lineWidth: 1)
+                        .strokeBorder(SnapColors.separator, lineWidth: 1)
                 )
         )
         .scaleEffect(isPressed ? 0.95 : 1.0)

--- a/Projects/App/Sources/Features/VoiceTyping/VoiceTypingView.swift
+++ b/Projects/App/Sources/Features/VoiceTyping/VoiceTypingView.swift
@@ -61,7 +61,7 @@ public struct VoiceTypingView: View {
 
             Text(statusText)
                 .font(.subheadline)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(SnapColors.textSecondary)
         }
     }
 
@@ -84,7 +84,7 @@ public struct VoiceTypingView: View {
             HStack {
                 Text("인식된 텍스트")
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(SnapColors.textSecondary)
 
                 Spacer()
 
@@ -93,7 +93,7 @@ public struct VoiceTypingView: View {
                         store.send(.clearText)
                     } label: {
                         Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(SnapColors.textSecondary)
                     }
                     .buttonStyle(.plain)
                 }
@@ -106,7 +106,7 @@ public struct VoiceTypingView: View {
             }
             .frame(minHeight: 100, maxHeight: 200)
             .padding()
-            .background(Color(.secondarySystemBackground))
+            .background(SnapColors.secondarySystemBackground)
             .clipShape(RoundedRectangle(cornerRadius: 12))
         }
     }
@@ -226,7 +226,7 @@ public struct VoiceTypingSection: View {
                     }
                 }
                 .padding()
-                .background(Color(.secondarySystemBackground))
+                .background(SnapColors.secondarySystemBackground)
                 .clipShape(RoundedRectangle(cornerRadius: 12))
             }
         }

--- a/Projects/App/Sources/Views/AppView.swift
+++ b/Projects/App/Sources/Views/AppView.swift
@@ -275,10 +275,10 @@ struct ProductivityTabView: View {
 
             Text("Window Snap, App Switcher, Macros")
                 .font(.subheadline)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(SnapColors.textSecondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(.systemBackground))
+        .background(SnapColors.systemBackground)
     }
 }
 
@@ -295,10 +295,10 @@ struct PresenterTabView: View {
 
             Text("Laser Pointer, Slides, Voice Typing")
                 .font(.subheadline)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(SnapColors.textSecondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(.systemBackground))
+        .background(SnapColors.systemBackground)
     }
 }
 


### PR DESCRIPTION
## Summary
- 시스템 동적 색상을 SnapColors 정적 색상으로 교체하여 테마 전환 시 깜빡임 제거
- Deep Dark Mode (OLED 최적화) 디자인 일관성 유지

## Changes
### SnapColors.swift
- 시스템 색상 대체용 별칭 추가 (systemBackground, secondarySystemBackground 등)

### 수정된 View 파일 (12개)
- KeyboardView, MediaView, TrackpadView
- LaserPointerView, PresenterView, VoiceTypingView
- MacroView, MacroEditorView, QuickLaunchView
- ShortsRemoteView, SettingsView, AppView

## Test plan
- [x] App 빌드 성공
- [ ] 시스템 설정에서 다크모드/라이트모드 전환 시 깜빡임 없음 확인
- [ ] 모든 화면에서 색상 일관성 확인

Close #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)