### PR TITLE
[Fix]: 키보드 입력 한글 조합 처리

### DIFF
--- a/Projects/App/Sources/Features/Keyboard/KeyboardFeature.swift
+++ b/Projects/App/Sources/Features/Keyboard/KeyboardFeature.swift
@@ -78,7 +78,11 @@ public struct KeyboardFeature {
                     return .run { [modifiers = state.activeModifiers.rawValue] _ in
                         for char in newCharacters {
                             if let keyCode = keyCode(for: char) {
+                                // 영문, 숫자, 특수문자: keyCode로 전송
                                 await client.sendKeyEvent(keyCode, .press, modifiers)
+                            } else {
+                                // 한글 등 keyCode 매핑이 없는 문자: 텍스트로 직접 전송
+                                await client.sendVoiceText(String(char), true)
                             }
                         }
                     }
@@ -91,9 +95,14 @@ public struct KeyboardFeature {
                 return .run { [modifiers = state.activeModifiers.rawValue] _ in
                     for char in text {
                         if let keyCode = keyCode(for: char) {
+                            // 영문, 숫자, 특수문자: keyCode로 전송
                             await client.sendKeyEvent(keyCode, .press, modifiers)
+                        } else {
+                            // 한글 등 keyCode 매핑이 없는 문자: 텍스트로 직접 전송
+                            await client.sendVoiceText(String(char), true)
                         }
                     }
+                    // Enter 키 전송
                     await client.sendKeyEvent(36, .press, 0)
                 }
 


### PR DESCRIPTION
## Summary
- 한글 등 keyCode 매핑이 없는 문자를 Mac으로 전송할 수 있도록 수정
- 기존 VoiceText 프로토콜을 활용하여 유니코드 문자 직접 전송

## Changes
### KeyboardFeature.swift
- `textChanged`: keyCode 매핑 없는 문자는 `sendVoiceText`로 전송
- `submitText`: 동일하게 수정

## How it works
1. 사용자가 iOS 키보드에서 한글 입력
2. keyCode 매핑 테이블에 없으면 `sendVoiceText(char, isFinal: true)` 호출
3. Mac에서 `VoiceText` 패킷 수신 후 `InputSimulator.typeText()`로 입력
4. `typeText()`는 `CGEvent.keyboardSetUnicodeString`을 사용하여 유니코드 문자 입력

## Test plan
- [x] App 빌드 성공
- [ ] 한글 입력 후 Mac에서 정상 입력 확인
- [ ] 영문 입력 기존 동작 유지 확인
- [ ] 한영 혼용 입력 테스트

Close #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)