### PR TITLE
[Chore]: GitHub Actions CI/CD 파이프라인 구축

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,127 @@
+name: CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: SwiftLint
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install SwiftLint
+        run: brew install swiftlint
+
+      - name: Run SwiftLint
+        run: swiftlint lint --config .swiftlint.yml --reporter github-actions-logging
+
+  build-ios:
+    name: Build & Test iOS
+    runs-on: macos-15
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode 16
+        run: sudo xcode-select -s /Applications/Xcode_16.app
+
+      - name: Install Tuist
+        run: |
+          curl -Ls https://install.tuist.io | bash
+          tuist version
+
+      - name: Cache Tuist
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/tuist
+            Tuist/.build
+          key: tuist-${{ hashFiles('Tuist/Package.swift', 'Tuist/Package.resolved') }}
+          restore-keys: tuist-
+
+      - name: Install Dependencies
+        run: tuist install
+
+      - name: Generate Project
+        run: tuist generate --no-open
+
+      - name: Build iOS App
+        run: |
+          xcodebuild build \
+            -workspace Snap.xcworkspace \
+            -scheme App \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -configuration Debug \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            ONLY_ACTIVE_ARCH=YES
+
+      - name: Run iOS Tests
+        run: |
+          xcodebuild test \
+            -workspace Snap.xcworkspace \
+            -scheme App \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -configuration Debug \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            ONLY_ACTIVE_ARCH=YES
+
+  build-macos:
+    name: Build & Test macOS
+    runs-on: macos-15
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode 16
+        run: sudo xcode-select -s /Applications/Xcode_16.app
+
+      - name: Install Tuist
+        run: |
+          curl -Ls https://install.tuist.io | bash
+          tuist version
+
+      - name: Cache Tuist
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/tuist
+            Tuist/.build
+          key: tuist-${{ hashFiles('Tuist/Package.swift', 'Tuist/Package.resolved') }}
+          restore-keys: tuist-
+
+      - name: Install Dependencies
+        run: tuist install
+
+      - name: Generate Project
+        run: tuist generate --no-open
+
+      - name: Build macOS App
+        run: |
+          xcodebuild build \
+            -workspace Snap.xcworkspace \
+            -scheme MacReceiver \
+            -configuration Debug \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            ONLY_ACTIVE_ARCH=YES
+
+      - name: Run macOS Tests
+        run: |
+          xcodebuild test \
+            -workspace Snap.xcworkspace \
+            -scheme MacReceiver \
+            -configuration Debug \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            ONLY_ACTIVE_ARCH=YES


### PR DESCRIPTION
## Summary
- GitHub Actions를 사용한 CI/CD 파이프라인 구축
- PR 및 main/develop 브랜치 push 시 자동 빌드 및 테스트

## Jobs
1. **SwiftLint** - 코드 스타일 검사
2. **Build & Test iOS** - iOS 앱 빌드 및 테스트
3. **Build & Test macOS** - macOS 앱 빌드 및 테스트

## Features
- Tuist 캐싱으로 빌드 시간 단축
- Concurrency 설정으로 중복 워크플로우 취소
- macos-15 runner (Xcode 16, Swift 6.0 지원)

Close #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)