### PR TITLE
[Feat]: 앱 스위처 순서 변경 기능 구현 (#115)

### DIFF
--- a/Projects/App/Sources/Features/Productivity/ProductivityFeature.swift
+++ b/Projects/App/Sources/Features/Productivity/ProductivityFeature.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import Foundation
 import Shared
 
 @Reducer
@@ -8,11 +9,25 @@ public struct ProductivityFeature {
         public var isSiriActive: Bool = false
         public var runningApps: [AppInfo] = []
         public var isLoadingApps: Bool = false
+        public var isAppSwitcherEditing: Bool = false
+        public var appOrder: [String] = []  // bundleID 순서
         public var macro: MacroFeature.State = .init()
         public var voiceTyping: VoiceTypingFeature.State = .init()
         public var presenter: PresenterFeature.State = .init()
         public var shortsRemote: ShortsRemoteFeature.State = .init()
         public var quickLaunch: QuickLaunchFeature.State = .init()
+
+        /// 저장된 순서에 따라 정렬된 앱 목록
+        public var sortedApps: [AppInfo] {
+            if appOrder.isEmpty {
+                return runningApps
+            }
+            return runningApps.sorted { app1, app2 in
+                let index1 = appOrder.firstIndex(of: app1.bundleID) ?? Int.max
+                let index2 = appOrder.firstIndex(of: app2.bundleID) ?? Int.max
+                return index1 < index2
+            }
+        }
     }
 
     public enum Action: Equatable, Sendable {
@@ -29,6 +44,10 @@ public struct ProductivityFeature {
         case requestAppListTapped
         case appListReceived([AppInfo])
         case appTapped(AppInfo)
+        case toggleAppSwitcherEditMode
+        case appMoved(from: IndexSet, to: Int)
+        case loadAppOrder
+        case saveAppOrder
 
         // Macro
         case macro(MacroFeature.Action)
@@ -122,6 +141,29 @@ public struct ProductivityFeature {
                 return .run { _ in
                     await client.sendAppFocus(app.bundleID, app.pid)
                 }
+
+            case .toggleAppSwitcherEditMode:
+                state.isAppSwitcherEditing.toggle()
+                return .none
+
+            case .appMoved(let from, let to):
+                var sortedApps = state.sortedApps
+                sortedApps.move(fromOffsets: from, toOffset: to)
+                state.appOrder = sortedApps.map { $0.bundleID }
+                return .send(.saveAppOrder)
+
+            case .loadAppOrder:
+                if let data = UserDefaults.standard.data(forKey: "snap.appSwitcher.order"),
+                   let order = try? JSONDecoder().decode([String].self, from: data) {
+                    state.appOrder = order
+                }
+                return .none
+
+            case .saveAppOrder:
+                if let data = try? JSONEncoder().encode(state.appOrder) {
+                    UserDefaults.standard.set(data, forKey: "snap.appSwitcher.order")
+                }
+                return .none
 
             case .macro:
                 return .none

--- a/Projects/App/Sources/Features/Productivity/ProductivityView.swift
+++ b/Projects/App/Sources/Features/Productivity/ProductivityView.swift
@@ -202,6 +202,23 @@ public struct ProductivityView: View {
 
                 Spacer()
 
+                if !store.runningApps.isEmpty {
+                    Button {
+                        Task { @MainActor in
+                            HapticManager.shared.buttonTap()
+                        }
+                        store.send(.toggleAppSwitcherEditMode)
+                    } label: {
+                        Text(store.isAppSwitcherEditing ? "완료" : "편집")
+                            .font(SnapTypography.labelSmall)
+                            .foregroundStyle(Color.accentColor)
+                    }
+                    .padding(.horizontal, SnapSpacing.md)
+                    .padding(.vertical, SnapSpacing.xs)
+                    .background(SnapColors.backgroundTertiary)
+                    .clipShape(Capsule())
+                }
+
                 Button {
                     Task { @MainActor in
                         HapticManager.shared.buttonTap()
@@ -254,16 +271,35 @@ public struct ProductivityView: View {
                     .disabled(store.isLoadingApps)
                 }
             } else {
-                // App grid
+                // App grid with reordering
+                let sortedApps = store.sortedApps
                 LazyVGrid(columns: [
                     GridItem(.flexible()),
                     GridItem(.flexible()),
                     GridItem(.flexible()),
                     GridItem(.flexible())
                 ], spacing: SnapSpacing.lg) {
-                    ForEach(store.runningApps, id: \.bundleID) { app in
-                        AppButton(app: app, isActive: app.isActive) {
-                            store.send(.appTapped(app))
+                    ForEach(Array(sortedApps.enumerated()), id: \.element.bundleID) { index, app in
+                        AppButton(
+                            app: app,
+                            isActive: app.isActive,
+                            isEditing: store.isAppSwitcherEditing
+                        ) {
+                            if !store.isAppSwitcherEditing {
+                                store.send(.appTapped(app))
+                            }
+                        }
+                        .draggable(app.bundleID) {
+                            AppDragPreview(app: app)
+                        }
+                        .dropDestination(for: String.self) { items, _ in
+                            guard let droppedBundleID = items.first,
+                                  let fromIndex = sortedApps.firstIndex(where: { $0.bundleID == droppedBundleID }) else {
+                                return false
+                            }
+                            HapticManager.shared.selection()
+                            store.send(.appMoved(from: IndexSet(integer: fromIndex), to: index))
+                            return true
                         }
                     }
                 }
@@ -271,6 +307,9 @@ public struct ProductivityView: View {
         }
         .padding(SnapSpacing.lg)
         .cardStyle()
+        .onAppear {
+            store.send(.loadAppOrder)
+        }
     }
 }
 
@@ -279,7 +318,10 @@ public struct ProductivityView: View {
 struct AppButton: View {
     let app: AppInfo
     let isActive: Bool
+    var isEditing: Bool = false
     let action: () -> Void
+
+    @State private var isWiggling = false
 
     var body: some View {
         Button {
@@ -317,12 +359,51 @@ struct AppButton: View {
             )
             .overlay(
                 RoundedRectangle(cornerRadius: SnapCornerRadius.md)
-                    .strokeBorder(isActive ? Color.accentColor.opacity(0.5) : Color.clear, lineWidth: 1)
+                    .strokeBorder(isEditing ? Color.accentColor : (isActive ? Color.accentColor.opacity(0.5) : Color.clear), lineWidth: isEditing ? 2 : 1)
             )
         }
         .buttonStyle(.plain)
         .pressEffect()
-        .accessibilityLabel("\(app.name) 앱\(isActive ? ", 활성화됨" : "")")
+        .rotationEffect(.degrees(isWiggling ? 1.5 : -1.5))
+        .animation(
+            isEditing ? .easeInOut(duration: 0.12).repeatForever(autoreverses: true) : .default,
+            value: isWiggling
+        )
+        .onChange(of: isEditing) { _, newValue in
+            isWiggling = newValue
+        }
+        .accessibilityLabel("\(app.name) 앱\(isActive ? ", 활성화됨" : "")\(isEditing ? ", 편집 모드" : "")")
+    }
+}
+
+// MARK: - App Drag Preview
+
+struct AppDragPreview: View {
+    let app: AppInfo
+
+    var body: some View {
+        VStack(spacing: SnapSpacing.xs) {
+            if let uiImage = UIImage(data: app.iconData) {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 56, height: 56)
+                    .clipShape(RoundedRectangle(cornerRadius: SnapCornerRadius.md))
+            } else {
+                Image(systemName: "app.fill")
+                    .font(.system(size: 40))
+                    .foregroundStyle(Color.accentColor)
+                    .frame(width: 56, height: 56)
+            }
+
+            Text(app.name)
+                .font(SnapTypography.caption)
+                .foregroundStyle(SnapColors.textPrimary)
+        }
+        .padding(SnapSpacing.sm)
+        .background(SnapColors.backgroundElevated)
+        .clipShape(RoundedRectangle(cornerRadius: SnapCornerRadius.md))
+        .shadow(color: .black.opacity(0.3), radius: 8, y: 4)
     }
 }
 


### PR DESCRIPTION
## Summary
- 앱 스위처에 순서 변경 기능 추가
- 편집 모드 진입 시 위글 애니메이션 표시
- 드래그 앤 드롭으로 앱 순서 재배치
- UserDefaults에 순서 영구 저장

## Changes
- `ProductivityFeature.swift`: 앱 순서 상태 및 액션 추가
- `ProductivityView.swift`: 드래그 앤 드롭 UI 구현, AppDragPreview 추가

## Test plan
- [ ] 앱 스위처에서 "편집" 버튼 탭 → 위글 모드 진입 확인
- [ ] 앱 아이콘 드래그로 순서 변경 확인
- [ ] 앱 재시작 후 순서 유지 확인

Close #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)