### PR TITLE
[Fix]: 에러 Alert 표시 통일 (#109)

### DIFF
--- a/Projects/App/Sources/Features/LaserPointer/LaserPointerFeature.swift
+++ b/Projects/App/Sources/Features/LaserPointer/LaserPointerFeature.swift
@@ -15,7 +15,7 @@ public struct LaserPointerFeature {
         public var isCalibrated: Bool = false
         public var sensitivity: Float = 15.0
         public var activationMode: ActivationMode = .hold
-        public var errorMessage: String?
+        @Presents public var alert: AlertState<Action.Alert>?
 
         public init() {}
     }
@@ -28,7 +28,12 @@ public struct LaserPointerFeature {
         case setSensitivity(Float)
         case setActivationMode(ActivationMode)
         case motionEvent(MotionEvent)
-        case dismissError
+        case alert(PresentationAction<Alert>)
+
+        @CasePathable
+        public enum Alert: Equatable, Sendable {
+            case dismiss
+        }
     }
 
     @Dependency(\.connectionClient) var connectionClient
@@ -52,12 +57,19 @@ public struct LaserPointerFeature {
 
             case .startPointing:
                 guard motionClient.isAvailable() else {
-                    state.errorMessage = "자이로스코프를 사용할 수 없습니다"
+                    state.alert = AlertState {
+                        TextState("오류")
+                    } actions: {
+                        ButtonState(action: .dismiss) {
+                            TextState("확인")
+                        }
+                    } message: {
+                        TextState("자이로스코프를 사용할 수 없습니다")
+                    }
                     return .none
                 }
 
                 state.isActive = true
-                state.errorMessage = nil
 
                 // 시작할 때 자동 캘리브레이션
                 motionClient.calibrate()
@@ -104,15 +116,23 @@ public struct LaserPointerFeature {
                     }
 
                 case .error(let message):
-                    state.errorMessage = message
+                    state.alert = AlertState {
+                        TextState("오류")
+                    } actions: {
+                        ButtonState(action: .dismiss) {
+                            TextState("확인")
+                        }
+                    } message: {
+                        TextState(message)
+                    }
                     state.isActive = false
                 }
                 return .none
 
-            case .dismissError:
-                state.errorMessage = nil
+            case .alert:
                 return .none
             }
         }
+        .ifLet(\.$alert, action: \.alert)
     }
 }

--- a/Projects/App/Sources/Features/LaserPointer/LaserPointerView.swift
+++ b/Projects/App/Sources/Features/LaserPointer/LaserPointerView.swift
@@ -23,19 +23,7 @@ public struct LaserPointerView: View {
             calibrateButton
         }
         .padding()
-        .alert(
-            "오류",
-            isPresented: .init(
-                get: { store.errorMessage != nil },
-                set: { if !$0 { store.send(.dismissError) } }
-            )
-        ) {
-            Button("확인") {
-                store.send(.dismissError)
-            }
-        } message: {
-            Text(store.errorMessage ?? "")
-        }
+        .alert($store.scope(state: \.alert, action: \.alert))
     }
 
     @ViewBuilder

--- a/Projects/App/Sources/Features/Trackpad/TrackpadView.swift
+++ b/Projects/App/Sources/Features/Trackpad/TrackpadView.swift
@@ -669,19 +669,7 @@ struct LaserControlArea: View {
             .padding(.horizontal)
         }
         .padding(.horizontal)
-        .alert(
-            "오류",
-            isPresented: Binding(
-                get: { store.laserPointer.errorMessage != nil },
-                set: { if !$0 { store.send(.laserPointer(.dismissError)) } }
-            )
-        ) {
-            Button("확인") {
-                store.send(.laserPointer(.dismissError))
-            }
-        } message: {
-            Text(store.laserPointer.errorMessage ?? "")
-        }
+        .alert($store.scope(state: \.laserPointer.alert, action: \.laserPointer.alert))
     }
 
     private func buttonLabel(isActive: Bool, mode: LaserPointerFeature.ActivationMode) -> String {

--- a/Projects/App/Sources/Features/VoiceTyping/VoiceTypingFeature.swift
+++ b/Projects/App/Sources/Features/VoiceTyping/VoiceTypingFeature.swift
@@ -1,6 +1,7 @@
 import ComposableArchitecture
 import Foundation
 import Speech
+import UIKit
 
 @Reducer
 public struct VoiceTypingFeature {
@@ -9,7 +10,7 @@ public struct VoiceTypingFeature {
         public var isRecording: Bool = false
         public var recognizedText: String = ""
         public var authorizationStatus: AuthorizationStatus = .notDetermined
-        public var errorMessage: String?
+        @Presents public var alert: AlertState<Action.Alert>?
 
         public enum AuthorizationStatus: Equatable, Sendable {
             case notDetermined
@@ -31,7 +32,13 @@ public struct VoiceTypingFeature {
         case recognitionEvent(SpeechRecognitionEvent)
         case sendText
         case clearText
-        case dismissError
+        case alert(PresentationAction<Alert>)
+
+        @CasePathable
+        public enum Alert: Equatable, Sendable {
+            case dismiss
+            case openSettings
+        }
     }
 
     @Dependency(\.connectionClient) var connectionClient
@@ -85,13 +92,23 @@ public struct VoiceTypingFeature {
 
             case .startRecording:
                 guard state.authorizationStatus == .authorized else {
-                    state.errorMessage = "음성 인식 권한이 필요합니다"
+                    state.alert = AlertState {
+                        TextState("권한 필요")
+                    } actions: {
+                        ButtonState(action: .openSettings) {
+                            TextState("설정 열기")
+                        }
+                        ButtonState(role: .cancel, action: .dismiss) {
+                            TextState("취소")
+                        }
+                    } message: {
+                        TextState("음성 인식 권한이 필요합니다. 설정에서 권한을 허용해주세요.")
+                    }
                     return .none
                 }
 
                 state.isRecording = true
                 state.recognizedText = ""
-                state.errorMessage = nil
 
                 let recognizer = speechRecognizer
                 return .run { send in
@@ -114,12 +131,28 @@ public struct VoiceTypingFeature {
                     }
 
                 case .error(let message):
-                    state.errorMessage = message
+                    state.alert = AlertState {
+                        TextState("오류")
+                    } actions: {
+                        ButtonState(action: .dismiss) {
+                            TextState("확인")
+                        }
+                    } message: {
+                        TextState(message)
+                    }
                     state.isRecording = false
 
                 case .availabilityChanged(let available):
                     if !available {
-                        state.errorMessage = "음성 인식을 사용할 수 없습니다"
+                        state.alert = AlertState {
+                            TextState("오류")
+                        } actions: {
+                            ButtonState(action: .dismiss) {
+                                TextState("확인")
+                            }
+                        } message: {
+                            TextState("음성 인식을 사용할 수 없습니다")
+                        }
                         state.isRecording = false
                     }
                 }
@@ -139,10 +172,19 @@ public struct VoiceTypingFeature {
                 state.recognizedText = ""
                 return .none
 
-            case .dismissError:
-                state.errorMessage = nil
+            case .alert(.presented(.openSettings)):
+                return .run { _ in
+                    await MainActor.run {
+                        if let url = URL(string: UIApplication.openSettingsURLString) {
+                            UIApplication.shared.open(url)
+                        }
+                    }
+                }
+
+            case .alert:
                 return .none
             }
         }
+        .ifLet(\.$alert, action: \.alert)
     }
 }

--- a/Projects/App/Sources/Features/VoiceTyping/VoiceTypingView.swift
+++ b/Projects/App/Sources/Features/VoiceTyping/VoiceTypingView.swift
@@ -23,19 +23,7 @@ public struct VoiceTypingView: View {
         .onAppear {
             store.send(.onAppear)
         }
-        .alert(
-            "오류",
-            isPresented: .init(
-                get: { store.errorMessage != nil },
-                set: { if !$0 { store.send(.dismissError) } }
-            )
-        ) {
-            Button("확인") {
-                store.send(.dismissError)
-            }
-        } message: {
-            Text(store.errorMessage ?? "")
-        }
+        .alert($store.scope(state: \.alert, action: \.alert))
     }
 
     @ViewBuilder

--- a/Projects/App/Sources/Models/AppError.swift
+++ b/Projects/App/Sources/Models/AppError.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+// MARK: - App Error
+
+/// 앱 전역 에러 타입
+public enum AppError: Equatable, Sendable, LocalizedError {
+    case connection(ConnectionErrorType)
+    case permission(PermissionErrorType)
+    case speech(SpeechErrorType)
+    case general(String)
+
+    // MARK: - Error Types
+
+    public enum ConnectionErrorType: Equatable, Sendable {
+        case discoveryFailed
+        case connectionFailed
+        case connectionLost
+        case timeout
+        case pairingFailed
+        case serverError(String)
+    }
+
+    public enum PermissionErrorType: Equatable, Sendable {
+        case speechRecognition
+        case microphone
+        case accessibility
+    }
+
+    public enum SpeechErrorType: Equatable, Sendable {
+        case notAvailable
+        case alreadyRecording
+        case requestCreationFailed
+        case audioEngineError
+    }
+
+    // MARK: - User Friendly Message
+
+    public var userMessage: String {
+        switch self {
+        case .connection(let type):
+            return type.message
+        case .permission(let type):
+            return type.message
+        case .speech(let type):
+            return type.message
+        case .general(let message):
+            return message
+        }
+    }
+
+    public var title: String {
+        switch self {
+        case .connection:
+            return "연결 오류"
+        case .permission:
+            return "권한 필요"
+        case .speech:
+            return "음성 인식 오류"
+        case .general:
+            return "오류"
+        }
+    }
+
+    public var errorDescription: String? {
+        userMessage
+    }
+
+    // MARK: - Retry Availability
+
+    public var canRetry: Bool {
+        switch self {
+        case .connection(let type):
+            switch type {
+            case .discoveryFailed, .connectionFailed, .timeout, .pairingFailed:
+                return true
+            case .connectionLost, .serverError:
+                return false
+            }
+        case .permission:
+            return false
+        case .speech(let type):
+            switch type {
+            case .notAvailable, .alreadyRecording:
+                return false
+            case .requestCreationFailed, .audioEngineError:
+                return true
+            }
+        case .general:
+            return false
+        }
+    }
+
+    // MARK: - Settings Navigation
+
+    public var shouldOpenSettings: Bool {
+        if case .permission = self {
+            return true
+        }
+        return false
+    }
+}
+
+// MARK: - Connection Error Type Messages
+
+extension AppError.ConnectionErrorType {
+    var message: String {
+        switch self {
+        case .discoveryFailed:
+            return "Mac을 찾을 수 없습니다. 동일한 네트워크에 연결되어 있는지 확인해주세요."
+        case .connectionFailed:
+            return "Mac에 연결할 수 없습니다. Mac에서 Snap Receiver가 실행 중인지 확인해주세요."
+        case .connectionLost:
+            return "연결이 끊어졌습니다. 네트워크 상태를 확인해주세요."
+        case .timeout:
+            return "연결 시간이 초과되었습니다. 다시 시도해주세요."
+        case .pairingFailed:
+            return "페어링에 실패했습니다. PIN 코드를 다시 확인해주세요."
+        case .serverError(let detail):
+            return "서버 오류: \(detail)"
+        }
+    }
+}
+
+// MARK: - Permission Error Type Messages
+
+extension AppError.PermissionErrorType {
+    var message: String {
+        switch self {
+        case .speechRecognition:
+            return "음성 인식 권한이 필요합니다. 설정에서 권한을 허용해주세요."
+        case .microphone:
+            return "마이크 권한이 필요합니다. 설정에서 권한을 허용해주세요."
+        case .accessibility:
+            return "접근성 권한이 필요합니다. Mac 시스템 환경설정에서 권한을 허용해주세요."
+        }
+    }
+}
+
+// MARK: - Speech Error Type Messages
+
+extension AppError.SpeechErrorType {
+    var message: String {
+        switch self {
+        case .notAvailable:
+            return "음성 인식을 사용할 수 없습니다."
+        case .alreadyRecording:
+            return "이미 녹음 중입니다."
+        case .requestCreationFailed:
+            return "음성 인식 요청을 생성할 수 없습니다."
+        case .audioEngineError:
+            return "오디오 엔진 오류가 발생했습니다."
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 에러 Alert을 TCA AlertState 패턴으로 통일
- 에러 타입별 사용자 친화적 메시지 제공
- 권한 에러 시 설정 열기 액션 추가

## Changes
- `Models/AppError.swift`: 통합 에러 타입 정의
  - ConnectionErrorType: 연결 관련 에러
  - PermissionErrorType: 권한 관련 에러
  - SpeechErrorType: 음성 인식 에러
- `LaserPointerFeature.swift`: TCA AlertState 적용
- `VoiceTypingFeature.swift`: TCA AlertState 적용 + 설정 열기 액션
- `TrackpadView.swift`: alert 바인딩 업데이트

## Benefits
- 일관된 에러 표시 UX
- TCA 표준 패턴 준수
- 권한 에러 시 원클릭으로 설정 이동

## Test plan
- [ ] 레이저 포인터 자이로스코프 오류 시 Alert 표시 확인
- [ ] 음성 인식 권한 거부 시 "설정 열기" 버튼 동작 확인
- [ ] 음성 인식 에러 시 Alert 표시 확인

Close #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)