### PR TITLE
[Fix]: 메모리 누수 방지를 위한 리소스 정리 개선

### DIFF
--- a/Projects/App/Sources/Features/VoiceTyping/VoiceTypingFeature.swift
+++ b/Projects/App/Sources/Features/VoiceTyping/VoiceTypingFeature.swift
@@ -42,8 +42,7 @@ public struct VoiceTypingFeature {
     }
 
     @Dependency(\.connectionClient) var connectionClient
-
-    private let speechRecognizer = SpeechRecognizer()
+    @Dependency(\.speechRecognizerClient) var speechRecognizerClient
 
     public init() {}
 
@@ -54,10 +53,9 @@ public struct VoiceTypingFeature {
                 return .send(.checkAuthorization)
 
             case .checkAuthorization:
-                let recognizer = speechRecognizer
-                return .run { send in
-                    let speechStatus = await recognizer.requestAuthorization()
-                    let micStatus = await recognizer.requestMicrophoneAuthorization()
+                return .run { [speechRecognizerClient] send in
+                    let speechStatus = await speechRecognizerClient.requestAuthorization()
+                    let micStatus = await speechRecognizerClient.requestMicrophoneAuthorization()
 
                     let status: State.AuthorizationStatus
                     if !micStatus {
@@ -110,16 +108,15 @@ public struct VoiceTypingFeature {
                 state.isRecording = true
                 state.recognizedText = ""
 
-                let recognizer = speechRecognizer
-                return .run { send in
-                    for await event in recognizer.startRecognition() {
+                return .run { [speechRecognizerClient] send in
+                    for await event in await speechRecognizerClient.startRecognition() {
                         await send(.recognitionEvent(event))
                     }
                 }
 
             case .stopRecording:
                 state.isRecording = false
-                speechRecognizer.stopRecognition()
+                speechRecognizerClient.stopRecognition()
                 return .none
 
             case .recognitionEvent(let event):

--- a/Projects/App/Sources/Services/SpeechRecognizer.swift
+++ b/Projects/App/Sources/Services/SpeechRecognizer.swift
@@ -28,6 +28,10 @@ public final class SpeechRecognizer: @unchecked Sendable {
         self.speechRecognizer = SFSpeechRecognizer(locale: locale)
     }
 
+    deinit {
+        stopRecognition()
+    }
+
     // MARK: - Authorization
 
     /// 음성 인식 권한 요청

--- a/Projects/App/Sources/Services/SpeechRecognizerClient.swift
+++ b/Projects/App/Sources/Services/SpeechRecognizerClient.swift
@@ -1,0 +1,50 @@
+import ComposableArchitecture
+import Foundation
+import Speech
+
+/// TCA 의존성 클라이언트 - 음성 인식
+public struct SpeechRecognizerClient: Sendable {
+    public var requestAuthorization: @Sendable () async -> SFSpeechRecognizerAuthorizationStatus
+    public var requestMicrophoneAuthorization: @Sendable () async -> Bool
+    public var startRecognition: @Sendable () async -> AsyncStream<SpeechRecognitionEvent>
+    public var stopRecognition: @Sendable () -> Void
+}
+
+// MARK: - Dependency Key
+
+extension SpeechRecognizerClient: DependencyKey {
+    public static var liveValue: SpeechRecognizerClient {
+        let recognizer = LockIsolated(SpeechRecognizer())
+
+        return SpeechRecognizerClient(
+            requestAuthorization: {
+                await recognizer.value.requestAuthorization()
+            },
+            requestMicrophoneAuthorization: {
+                await recognizer.value.requestMicrophoneAuthorization()
+            },
+            startRecognition: {
+                recognizer.value.startRecognition()
+            },
+            stopRecognition: {
+                recognizer.value.stopRecognition()
+            }
+        )
+    }
+
+    public static var testValue: SpeechRecognizerClient {
+        SpeechRecognizerClient(
+            requestAuthorization: { .authorized },
+            requestMicrophoneAuthorization: { true },
+            startRecognition: { .finished },
+            stopRecognition: {}
+        )
+    }
+}
+
+public extension DependencyValues {
+    var speechRecognizerClient: SpeechRecognizerClient {
+        get { self[SpeechRecognizerClient.self] }
+        set { self[SpeechRecognizerClient.self] = newValue }
+    }
+}

--- a/Projects/Shared/Sources/Network/Bonjour/BonjourBrowser.swift
+++ b/Projects/Shared/Sources/Network/Bonjour/BonjourBrowser.swift
@@ -49,6 +49,10 @@ public final class BonjourBrowser: @unchecked Sendable {
         self.queue = DispatchQueue(label: "com.snap.bonjour.browser", qos: .userInitiated)
     }
 
+    deinit {
+        stopSearching()
+    }
+
     // MARK: - Public Methods
 
     /// 검색 시작
@@ -131,6 +135,27 @@ public final class BonjourBrowser: @unchecked Sendable {
         }
     }
 
+    /// 서비스 리졸브 타임아웃 (초)
+    private static let resolveTimeout: TimeInterval = 5.0
+
+    /// 리졸브 상태를 추적하기 위한 래퍼 클래스
+    private final class ResolveState: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _isResolved = false
+
+        var isResolved: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return _isResolved
+        }
+
+        func markResolved() {
+            lock.lock()
+            defer { lock.unlock() }
+            _isResolved = true
+        }
+    }
+
     private func resolveService(_ result: NWBrowser.Result) {
         guard case .service(let name, _, _, _) = result.endpoint else {
             return
@@ -140,12 +165,14 @@ public final class BonjourBrowser: @unchecked Sendable {
         parameters.includePeerToPeer = true
 
         let connection = NWConnection(to: result.endpoint, using: parameters)
+        let resolveState = ResolveState()
 
         connection.stateUpdateHandler = { [weak self, weak connection] state in
-            guard let self else { return }
+            guard let self, !resolveState.isResolved else { return }
 
             switch state {
             case .ready:
+                resolveState.markResolved()
                 if let path = connection?.currentPath,
                    let endpoint = path.remoteEndpoint,
                    case .hostPort(let host, let port) = endpoint {
@@ -169,6 +196,7 @@ public final class BonjourBrowser: @unchecked Sendable {
                 connection?.cancel()
 
             case .failed, .cancelled:
+                resolveState.markResolved()
                 connection?.cancel()
 
             default:
@@ -177,6 +205,13 @@ public final class BonjourBrowser: @unchecked Sendable {
         }
 
         connection.start(queue: queue)
+
+        // 타임아웃: 일정 시간 후에도 리졸브되지 않으면 연결 취소
+        queue.asyncAfter(deadline: .now() + Self.resolveTimeout) { [weak connection] in
+            guard !resolveState.isResolved else { return }
+            logger.debug("Service resolve timeout for: \(name)")
+            connection?.cancel()
+        }
     }
 
     private func removeService(_ result: NWBrowser.Result) {

--- a/Projects/Shared/Sources/Network/Connection/HeartbeatManager.swift
+++ b/Projects/Shared/Sources/Network/Connection/HeartbeatManager.swift
@@ -46,6 +46,10 @@ public final class HeartbeatManager: @unchecked Sendable {
         self.queue = DispatchQueue(label: "com.snap.heartbeat", qos: .utility)
     }
 
+    deinit {
+        stop()
+    }
+
     // MARK: - Public Methods
 
     /// 하트비트 시작


### PR DESCRIPTION
## Summary
- HeartbeatManager에 deinit 추가로 DispatchSourceTimer 자동 정리
- BonjourBrowser에 deinit 추가 및 서비스 리졸브 타임아웃 (5초) 구현
- SpeechRecognizer에 deinit 추가로 오디오 엔진/인식 태스크 정리
- VoiceTypingFeature를 TCA 패턴에 맞게 SpeechRecognizerClient 의존성으로 리팩터링

## Changes
| 파일 | 변경 내용 |
|------|-----------|
| HeartbeatManager.swift | `deinit { stop() }` 추가 |
| BonjourBrowser.swift | `deinit { stopSearching() }` 및 5초 타임아웃 추가 |
| SpeechRecognizer.swift | `deinit { stopRecognition() }` 추가 |
| SpeechRecognizerClient.swift | 새 TCA 의존성 클라이언트 |
| VoiceTypingFeature.swift | `speechRecognizerClient` 의존성 사용으로 변경 |

## Test plan
- [x] iOS 앱 빌드 성공
- [x] macOS 앱 빌드 성공
- [ ] 앱 연결/해제 반복 후 메모리 증가 확인
- [ ] 음성 인식 시작/중지 반복 후 메모리 확인

Close #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)