### PR TITLE
[Feat]: 네트워크 재연결 로직 개선

### DIFF
--- a/Projects/App/Sources/Features/Connection/ConnectionFeature.swift
+++ b/Projects/App/Sources/Features/Connection/ConnectionFeature.swift
@@ -18,6 +18,12 @@ public struct ConnectionFeature: Sendable {
         public var pairingServerName: String = ""
         public var pairingPinCode: String = ""
 
+        // Reconnection
+        public var isAutoReconnectEnabled: Bool = true
+        public var lastConnectedDevice: Device?
+        public var reconnectAttempt: Int = 0
+        public var networkInterface: NetworkInterface = .other
+
         public init() {}
     }
 
@@ -32,6 +38,20 @@ public struct ConnectionFeature: Sendable {
         case disconnect
         case connectionEvent(ConnectionEvent)
 
+        // Reconnection
+        case attemptReconnect
+        case cancelReconnect
+        case reconnectDelayCompleted
+
+        // Network Monitoring
+        case startNetworkMonitoring
+        case stopNetworkMonitoring
+        case networkStatusChanged(NetworkStatusEvent)
+
+        // App Lifecycle
+        case appDidBecomeActive
+        case appWillResignActive
+
         // App List
         case appListReceived([AppInfo])
         case focusApp(bundleID: String, pid: UInt32)
@@ -44,23 +64,52 @@ public struct ConnectionFeature: Sendable {
         case submitPairingPin
         case cancelPairing
 
+        // Settings
+        case setAutoReconnect(Bool)
+
         // Error
         case errorOccurred(ConnectionError)
         case clearError
     }
 
     @Dependency(\.connectionClient) var connectionClient
+    @Dependency(\.networkMonitorClient) var networkMonitorClient
+    @Dependency(\.continuousClock) var clock
 
     public init() {}
 
     private enum CancelID {
         case discovery
         case connection
+        case reconnect
+        case networkMonitor
+    }
+
+    // MARK: - Reconnection Configuration
+
+    /// 최대 재시도 횟수
+    private static let maxReconnectAttempts = 5
+
+    /// 기본 재연결 지연 시간 (초)
+    private static let baseReconnectDelay: Double = 1.0
+
+    /// 최대 재연결 지연 시간 (초)
+    private static let maxReconnectDelay: Double = 30.0
+
+    /// Exponential backoff 지연 시간 계산
+    private func reconnectDelay(for attempt: Int) -> Duration {
+        let delay = min(
+            Self.baseReconnectDelay * pow(2.0, Double(attempt)),
+            Self.maxReconnectDelay
+        )
+        return .seconds(delay)
     }
 
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
+            // MARK: - Discovery
+
             case .startDiscovery:
                 guard state.status == .disconnected else { return .none }
                 state.status = .discovering
@@ -99,28 +148,38 @@ public struct ConnectionFeature: Sendable {
                 }
                 return .none
 
+            // MARK: - Connection
+
             case .connect(let device):
                 state.status = .connecting(device)
                 state.lastError = nil
+                state.reconnectAttempt = 0
+                state.lastConnectedDevice = device
 
-                return .run { send in
-                    do {
-                        for try await event in try await connectionClient.connect(device.host, device.port) {
-                            await send(.connectionEvent(event))
+                return .merge(
+                    .cancel(id: CancelID.reconnect),
+                    .run { send in
+                        do {
+                            for try await event in try await connectionClient.connect(device.host, device.port) {
+                                await send(.connectionEvent(event))
+                            }
+                        } catch {
+                            await send(.connectionEvent(.error(error.localizedDescription)))
                         }
-                    } catch {
-                        await send(.connectionEvent(.error(error.localizedDescription)))
                     }
-                }
-                .cancellable(id: CancelID.connection)
+                    .cancellable(id: CancelID.connection)
+                )
 
             case .disconnect:
                 state.status = .disconnected
                 state.connectedDevice = nil
+                state.lastConnectedDevice = nil
                 state.latency = 0
                 state.signalStrength = .unknown
+                state.reconnectAttempt = 0
                 return .merge(
                     .cancel(id: CancelID.connection),
+                    .cancel(id: CancelID.reconnect),
                     .run { _ in await connectionClient.disconnect() }
                 )
 
@@ -129,19 +188,39 @@ public struct ConnectionFeature: Sendable {
                 case .connected(let serverName):
                     state.isPairingRequired = false
                     state.pairingPinCode = ""
+                    state.reconnectAttempt = 0
                     if case .connecting(var device) = state.status {
                         device.name = serverName
                         state.status = .connected(device)
                         state.connectedDevice = device
+                        state.lastConnectedDevice = device
+                    } else if case .reconnecting(var device, _) = state.status {
+                        device.name = serverName
+                        state.status = .connected(device)
+                        state.connectedDevice = device
+                        state.lastConnectedDevice = device
                     }
 
                 case .disconnected(let errorMessage):
-                    state.status = .disconnected
+                    let previousDevice = state.connectedDevice ?? state.lastConnectedDevice
                     state.connectedDevice = nil
                     state.isPairingRequired = false
                     state.pairingPinCode = ""
+
                     if let message = errorMessage {
                         state.lastError = .connectionLost(message)
+                    }
+
+                    // 자동 재연결 시도
+                    if state.isAutoReconnectEnabled,
+                       let device = previousDevice,
+                       state.reconnectAttempt < Self.maxReconnectAttempts {
+                        state.reconnectAttempt += 1
+                        state.status = .reconnecting(device, attempt: state.reconnectAttempt)
+                        return .send(.attemptReconnect)
+                    } else {
+                        state.status = .disconnected
+                        state.reconnectAttempt = 0
                     }
 
                 case .packet(let packetEvent):
@@ -156,20 +235,39 @@ public struct ConnectionFeature: Sendable {
 
                 case .error(let message):
                     state.lastError = .connectionFailed(message)
-                    if case .connecting = state.status {
-                        state.status = .disconnected
+
+                    // 연결 중 에러 발생 시 재연결 시도
+                    if case .connecting(let device) = state.status {
+                        if state.isAutoReconnectEnabled,
+                           state.reconnectAttempt < Self.maxReconnectAttempts {
+                            state.reconnectAttempt += 1
+                            state.status = .reconnecting(device, attempt: state.reconnectAttempt)
+                            return .send(.attemptReconnect)
+                        } else {
+                            state.status = .disconnected
+                            state.reconnectAttempt = 0
+                        }
+                    } else if case .reconnecting(let device, _) = state.status {
+                        if state.reconnectAttempt < Self.maxReconnectAttempts {
+                            state.reconnectAttempt += 1
+                            state.status = .reconnecting(device, attempt: state.reconnectAttempt)
+                            return .send(.attemptReconnect)
+                        } else {
+                            state.status = .disconnected
+                            state.reconnectAttempt = 0
+                        }
                     }
 
                 case .pairingRequired(let serverName):
                     state.isPairingRequired = true
                     state.pairingServerName = serverName
                     state.pairingPinCode = ""
+                    state.reconnectAttempt = 0
 
                 case .pairingResult(let success, let message):
                     if success {
                         state.isPairingRequired = false
                         state.pairingPinCode = ""
-                        // 연결은 서버가 handshake 응답 후 처리됨
                     } else {
                         state.lastError = .pairingFailed(message)
                         state.pairingPinCode = ""
@@ -177,12 +275,101 @@ public struct ConnectionFeature: Sendable {
                 }
                 return .none
 
+            // MARK: - Reconnection
+
+            case .attemptReconnect:
+                guard case .reconnecting(let device, let attempt) = state.status else {
+                    return .none
+                }
+
+                let delay = reconnectDelay(for: attempt - 1)
+
+                return .run { send in
+                    try await clock.sleep(for: delay)
+                    await send(.reconnectDelayCompleted)
+                }
+                .cancellable(id: CancelID.reconnect)
+
+            case .cancelReconnect:
+                state.status = .disconnected
+                state.reconnectAttempt = 0
+                return .merge(
+                    .cancel(id: CancelID.reconnect),
+                    .cancel(id: CancelID.connection)
+                )
+
+            case .reconnectDelayCompleted:
+                guard case .reconnecting(let device, _) = state.status else {
+                    return .none
+                }
+
+                return .run { send in
+                    do {
+                        for try await event in try await connectionClient.connect(device.host, device.port) {
+                            await send(.connectionEvent(event))
+                        }
+                    } catch {
+                        await send(.connectionEvent(.error(error.localizedDescription)))
+                    }
+                }
+                .cancellable(id: CancelID.connection)
+
+            // MARK: - Network Monitoring
+
+            case .startNetworkMonitoring:
+                return .run { send in
+                    for await event in await networkMonitorClient.startMonitoring() {
+                        await send(.networkStatusChanged(event))
+                    }
+                }
+                .cancellable(id: CancelID.networkMonitor)
+
+            case .stopNetworkMonitoring:
+                networkMonitorClient.stopMonitoring()
+                return .cancel(id: CancelID.networkMonitor)
+
+            case .networkStatusChanged(let event):
+                switch event {
+                case .connected(let interface):
+                    let previousInterface = state.networkInterface
+                    state.networkInterface = interface
+
+                    // 네트워크 인터페이스가 변경되었고, 이전에 연결된 디바이스가 있으면 재연결 시도
+                    if previousInterface != interface,
+                       state.status == .disconnected,
+                       state.isAutoReconnectEnabled,
+                       let device = state.lastConnectedDevice {
+                        state.reconnectAttempt = 0
+                        return .send(.connect(device))
+                    }
+
+                case .disconnected:
+                    state.networkInterface = .other
+                }
+                return .none
+
+            // MARK: - App Lifecycle
+
+            case .appDidBecomeActive:
+                // 포그라운드 전환 시 연결이 끊겼으면 재연결 시도
+                if state.status == .disconnected,
+                   state.isAutoReconnectEnabled,
+                   let device = state.lastConnectedDevice {
+                    state.reconnectAttempt = 0
+                    return .send(.connect(device))
+                }
+                return .none
+
+            case .appWillResignActive:
+                // 백그라운드 전환 시 처리 (필요시)
+                return .none
+
+            // MARK: - App List & Now Playing
+
             case .appListReceived:
-                // Handled by parent feature
                 return .none
 
             case .nowPlayingInfoReceived:
-                // Handled by parent feature
                 return .none
 
             case .focusApp(let bundleID, let pid):
@@ -190,8 +377,9 @@ public struct ConnectionFeature: Sendable {
                     await connectionClient.sendAppFocus(bundleID, pid)
                 }
 
+            // MARK: - Pairing
+
             case .pairingPinCodeChanged(let pin):
-                // 4자리 숫자만 허용
                 let filtered = String(pin.filter { $0.isNumber }.prefix(4))
                 state.pairingPinCode = filtered
                 return .none
@@ -209,6 +397,25 @@ public struct ConnectionFeature: Sendable {
                 return .run { _ in
                     await connectionClient.disconnect()
                 }
+
+            // MARK: - Settings
+
+            case .setAutoReconnect(let enabled):
+                state.isAutoReconnectEnabled = enabled
+                if !enabled {
+                    // 자동 재연결 비활성화 시 진행 중인 재연결 취소
+                    if case .reconnecting = state.status {
+                        state.status = .disconnected
+                        state.reconnectAttempt = 0
+                        return .merge(
+                            .cancel(id: CancelID.reconnect),
+                            .cancel(id: CancelID.connection)
+                        )
+                    }
+                }
+                return .none
+
+            // MARK: - Error
 
             case .errorOccurred(let error):
                 state.lastError = error

--- a/Projects/App/Sources/Services/NetworkMonitorClient.swift
+++ b/Projects/App/Sources/Services/NetworkMonitorClient.swift
@@ -1,0 +1,127 @@
+import ComposableArchitecture
+import Foundation
+import Network
+
+/// 네트워크 상태 이벤트
+public enum NetworkStatusEvent: Equatable, Sendable {
+    case connected(NetworkInterface)
+    case disconnected
+}
+
+/// 네트워크 인터페이스 유형
+public enum NetworkInterface: Equatable, Sendable {
+    case wifi
+    case cellular
+    case wiredEthernet
+    case other
+}
+
+/// TCA 의존성 클라이언트 - 네트워크 상태 모니터링
+public struct NetworkMonitorClient: Sendable {
+    public var startMonitoring: @Sendable () async -> AsyncStream<NetworkStatusEvent>
+    public var stopMonitoring: @Sendable () -> Void
+    public var currentStatus: @Sendable () -> NetworkStatusEvent
+}
+
+// MARK: - Dependency Key
+
+extension NetworkMonitorClient: DependencyKey {
+    public static var liveValue: NetworkMonitorClient {
+        let monitor = NetworkMonitor()
+
+        return NetworkMonitorClient(
+            startMonitoring: {
+                monitor.start()
+            },
+            stopMonitoring: {
+                monitor.stop()
+            },
+            currentStatus: {
+                monitor.currentStatus
+            }
+        )
+    }
+
+    public static var testValue: NetworkMonitorClient {
+        NetworkMonitorClient(
+            startMonitoring: { .finished },
+            stopMonitoring: {},
+            currentStatus: { .connected(.wifi) }
+        )
+    }
+}
+
+public extension DependencyValues {
+    var networkMonitorClient: NetworkMonitorClient {
+        get { self[NetworkMonitorClient.self] }
+        set { self[NetworkMonitorClient.self] = newValue }
+    }
+}
+
+// MARK: - Network Monitor Implementation
+
+private final class NetworkMonitor: @unchecked Sendable {
+    private let monitor = NWPathMonitor()
+    private let queue = DispatchQueue(label: "com.snap.network.monitor", qos: .utility)
+    private var continuation: AsyncStream<NetworkStatusEvent>.Continuation?
+    private var _currentStatus: NetworkStatusEvent = .disconnected
+    private let lock = NSLock()
+
+    var currentStatus: NetworkStatusEvent {
+        lock.lock()
+        defer { lock.unlock() }
+        return _currentStatus
+    }
+
+    func start() -> AsyncStream<NetworkStatusEvent> {
+        AsyncStream { [weak self] continuation in
+            self?.continuation = continuation
+
+            self?.monitor.pathUpdateHandler = { [weak self] path in
+                guard let self else { return }
+
+                let status: NetworkStatusEvent
+                if path.status == .satisfied {
+                    let interface = self.determineInterface(path)
+                    status = .connected(interface)
+                } else {
+                    status = .disconnected
+                }
+
+                self.lock.lock()
+                let previousStatus = self._currentStatus
+                self._currentStatus = status
+                self.lock.unlock()
+
+                // 상태가 변경된 경우에만 이벤트 발생
+                if previousStatus != status {
+                    continuation.yield(status)
+                }
+            }
+
+            self?.monitor.start(queue: self?.queue ?? .main)
+
+            continuation.onTermination = { [weak self] _ in
+                self?.stop()
+            }
+        }
+    }
+
+    func stop() {
+        monitor.cancel()
+        continuation?.finish()
+        continuation = nil
+    }
+
+    private func determineInterface(_ path: NWPath) -> NetworkInterface {
+        if path.usesInterfaceType(.wifi) {
+            return .wifi
+        } else if path.usesInterfaceType(.cellular) {
+            return .cellular
+        } else if path.usesInterfaceType(.wiredEthernet) {
+            return .wiredEthernet
+        } else {
+            return .other
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Exponential backoff 재연결 전략 구현 (1초 → 2초 → 4초 → 8초 → 16초, 최대 30초)
- 최대 5회 재시도 후 포기, 상태를 disconnected로 전환
- `NetworkMonitorClient` TCA 의존성 추가 (NWPathMonitor 기반)
- 네트워크 인터페이스 변경 시 (Wi-Fi ↔ Cellular) 자동 재연결
- 앱이 백그라운드에서 포그라운드로 전환 시 자동 재연결
- 기존 `.reconnecting(Device, attempt: Int)` 상태 활용

## Changes
| 파일 | 변경 내용 |
|------|-----------|
| ConnectionFeature.swift | 재연결 로직 추가, 네트워크 모니터링, 앱 라이프사이클 처리 |
| NetworkMonitorClient.swift | 새 TCA 의존성 - NWPathMonitor 래핑 |

## Implementation Details
```
재연결 지연: min(baseDelay * 2^attempt, maxDelay)
baseDelay = 1초
maxDelay = 30초
maxAttempts = 5
```

## Test plan
- [x] iOS 앱 빌드 성공
- [ ] 연결 중 네트워크 끊김 → 자동 재연결 시도 확인
- [ ] 최대 시도 후 포기 확인
- [ ] Wi-Fi ↔ Cellular 전환 시 재연결 확인
- [ ] 백그라운드 → 포그라운드 전환 시 재연결 확인

Close #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)