### PR TITLE
[Feat]: TCP 연결 타임아웃 처리 개선

### DIFF
--- a/Projects/Shared/Sources/Network/Connection/ConnectionState.swift
+++ b/Projects/Shared/Sources/Network/Connection/ConnectionState.swift
@@ -8,6 +8,19 @@ public enum ConnectionState: Sendable, Equatable {
     case disconnecting
 }
 
+/// 연결 타임아웃 에러
+public struct ConnectionTimeoutError: Error, LocalizedError, Sendable {
+    public let timeout: TimeInterval
+
+    public init(timeout: TimeInterval = NetworkConstants.connectionTimeout) {
+        self.timeout = timeout
+    }
+
+    public var errorDescription: String? {
+        "연결 시간이 초과되었습니다 (\(Int(timeout))초)"
+    }
+}
+
 /// 연결 정보
 public struct ConnectionInfo: Sendable, Equatable {
     public let deviceName: String

--- a/Projects/Shared/Sources/Network/Connection/TCPConnection.swift
+++ b/Projects/Shared/Sources/Network/Connection/TCPConnection.swift
@@ -25,10 +25,21 @@ public final class TCPConnection: @unchecked Sendable {
     public private(set) var state: ConnectionState = .disconnected
     public let isSecure: Bool
 
+    /// 연결 타임아웃 (초)
+    public var connectionTimeout: TimeInterval
+
+    private var timeoutWorkItem: DispatchWorkItem?
+
     // MARK: - Initialization
 
     /// 클라이언트로 초기화 (호스트에 연결)
-    public init(host: String, port: UInt16, useTLS: Bool = false, tlsOptions: NWProtocolTLS.Options? = nil) {
+    public init(
+        host: String,
+        port: UInt16,
+        useTLS: Bool = false,
+        tlsOptions: NWProtocolTLS.Options? = nil,
+        timeout: TimeInterval = NetworkConstants.connectionTimeout
+    ) {
         let endpoint = NWEndpoint.hostPort(
             host: NWEndpoint.Host(host),
             port: NWEndpoint.Port(rawValue: port) ?? .any
@@ -49,6 +60,7 @@ public final class TCPConnection: @unchecked Sendable {
 
         self.connection = NWConnection(to: endpoint, using: parameters)
         self.queue = DispatchQueue(label: "com.snap.tcp.client", qos: .userInteractive)
+        self.connectionTimeout = timeout
 
         setupConnection()
     }
@@ -58,8 +70,13 @@ public final class TCPConnection: @unchecked Sendable {
         self.connection = connection
         self.isSecure = isSecure
         self.queue = DispatchQueue(label: "com.snap.tcp.server", qos: .userInteractive)
+        self.connectionTimeout = NetworkConstants.connectionTimeout
 
         setupConnection()
+    }
+
+    deinit {
+        cancelTimeoutTimer()
     }
 
     // MARK: - Public Methods
@@ -68,6 +85,10 @@ public final class TCPConnection: @unchecked Sendable {
     public func connect() {
         guard state == .disconnected else { return }
         state = .connecting
+
+        // 타임아웃 타이머 시작
+        startTimeoutTimer()
+
         connection.start(queue: queue)
     }
 
@@ -75,7 +96,33 @@ public final class TCPConnection: @unchecked Sendable {
     public func disconnect() {
         guard state == .connected || state == .connecting else { return }
         state = .disconnecting
+
+        // 타임아웃 타이머 취소
+        cancelTimeoutTimer()
+
         connection.cancel()
+    }
+
+    // MARK: - Timeout
+
+    private func startTimeoutTimer() {
+        cancelTimeoutTimer()
+
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self, self.state == .connecting else { return }
+            logger.warning("Connection timeout after \(self.connectionTimeout) seconds")
+            self.state = .disconnected
+            self.connection.cancel()
+            self.delegate?.tcpConnectionDidDisconnect(self, error: ConnectionTimeoutError())
+        }
+
+        timeoutWorkItem = workItem
+        queue.asyncAfter(deadline: .now() + connectionTimeout, execute: workItem)
+    }
+
+    private func cancelTimeoutTimer() {
+        timeoutWorkItem?.cancel()
+        timeoutWorkItem = nil
     }
 
     /// 데이터 전송
@@ -120,6 +167,7 @@ public final class TCPConnection: @unchecked Sendable {
             break
 
         case .ready:
+            cancelTimeoutTimer()
             state = .connected
             delegate?.tcpConnectionDidConnect(self)
             startReceiving()
@@ -128,10 +176,12 @@ public final class TCPConnection: @unchecked Sendable {
             logger.debug("Waiting: \(error.localizedDescription)")
 
         case .failed(let error):
+            cancelTimeoutTimer()
             state = .disconnected
             delegate?.tcpConnectionDidDisconnect(self, error: error)
 
         case .cancelled:
+            cancelTimeoutTimer()
             state = .disconnected
             delegate?.tcpConnectionDidDisconnect(self, error: nil)
 


### PR DESCRIPTION
## Summary
- TCP 연결에 설정 가능한 타임아웃 추가
- 타임아웃 발생 시 명확한 에러 메시지 제공

## Changes
| 파일 | 변경 내용 |
|------|-----------|
| TCPConnection.swift | `connectionTimeout` 프로퍼티 및 타임아웃 타이머 추가 |
| ConnectionState.swift | `ConnectionTimeoutError` 에러 타입 추가 |

## Implementation
- 기본 타임아웃: 15초 (NetworkConstants.connectionTimeout)
- 연결 시도 시 타이머 시작
- 연결 성공/실패/취소 시 타이머 취소
- 타임아웃 시 `ConnectionTimeoutError`와 함께 연결 해제

## Test plan
- [x] iOS 앱 빌드 성공
- [x] macOS 앱 빌드 성공
- [ ] 연결 타임아웃 시 에러 메시지 확인

Close #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)