### PR TITLE
[Fix]: 네트워크 에러 로깅 개선

### DIFF
--- a/Projects/Shared/Sources/Network/Bonjour/BonjourAdvertiser.swift
+++ b/Projects/Shared/Sources/Network/Bonjour/BonjourAdvertiser.swift
@@ -2,7 +2,7 @@ import Foundation
 import Network
 import os
 
-private let logger = Logger(subsystem: "com.snap.shared", category: "BonjourAdvertiser")
+private let logger = NetworkLogger.bonjour
 
 /// Bonjour 광고자 델리게이트
 public protocol BonjourAdvertiserDelegate: AnyObject, Sendable {

--- a/Projects/Shared/Sources/Network/Bonjour/BonjourBrowser.swift
+++ b/Projects/Shared/Sources/Network/Bonjour/BonjourBrowser.swift
@@ -2,7 +2,7 @@ import Foundation
 import Network
 import os
 
-private let logger = Logger(subsystem: "com.snap.shared", category: "BonjourBrowser")
+private let logger = NetworkLogger.bonjour
 
 /// 발견된 서비스 정보
 public struct DiscoveredService: Sendable, Equatable, Identifiable {

--- a/Projects/Shared/Sources/Network/Connection/ConnectionState.swift
+++ b/Projects/Shared/Sources/Network/Connection/ConnectionState.swift
@@ -1,11 +1,20 @@
 import Foundation
 
 /// 연결 상태
-public enum ConnectionState: Sendable, Equatable {
+public enum ConnectionState: Sendable, Equatable, CustomStringConvertible {
     case disconnected
     case connecting
     case connected
     case disconnecting
+
+    public var description: String {
+        switch self {
+        case .disconnected: return "disconnected"
+        case .connecting: return "connecting"
+        case .connected: return "connected"
+        case .disconnecting: return "disconnecting"
+        }
+    }
 }
 
 /// 연결 타임아웃 에러

--- a/Projects/Shared/Sources/Network/Connection/TCPConnection.swift
+++ b/Projects/Shared/Sources/Network/Connection/TCPConnection.swift
@@ -2,7 +2,7 @@ import Foundation
 import Network
 import os
 
-private let logger = Logger(subsystem: "com.snap.shared", category: "TCPConnection")
+private let logger = NetworkLogger.tcp
 
 /// TCP 연결 델리게이트
 public protocol TCPConnectionDelegate: AnyObject, Sendable {
@@ -159,34 +159,45 @@ public final class TCPConnection: @unchecked Sendable {
     }
 
     private func handleStateChange(_ newState: NWConnection.State) {
+        let previousState = state
+
         switch newState {
         case .setup:
-            break
+            logger.debug("Connection setup")
 
         case .preparing:
-            break
+            logger.debug("Connection preparing")
 
         case .ready:
             cancelTimeoutTimer()
             state = .connected
+            NetworkLogger.logConnectionStateChange(
+                from: previousState.description,
+                to: "connected"
+            )
             delegate?.tcpConnectionDidConnect(self)
             startReceiving()
 
         case .waiting(let error):
-            logger.debug("Waiting: \(error.localizedDescription)")
+            logger.warning("Connection waiting: \(error.localizedDescription)")
 
         case .failed(let error):
             cancelTimeoutTimer()
             state = .disconnected
+            NetworkLogger.logConnectionError(error, context: "connection failed")
             delegate?.tcpConnectionDidDisconnect(self, error: error)
 
         case .cancelled:
             cancelTimeoutTimer()
             state = .disconnected
+            NetworkLogger.logConnectionStateChange(
+                from: previousState.description,
+                to: "disconnected"
+            )
             delegate?.tcpConnectionDidDisconnect(self, error: nil)
 
         @unknown default:
-            break
+            logger.warning("Unknown connection state")
         }
     }
 

--- a/Projects/Shared/Sources/Network/Connection/TCPServer.swift
+++ b/Projects/Shared/Sources/Network/Connection/TCPServer.swift
@@ -2,7 +2,7 @@ import Foundation
 import Network
 import os
 
-private let logger = Logger(subsystem: "com.snap.shared", category: "TCPServer")
+private let logger = NetworkLogger.tcp
 
 /// TCP 서버 델리게이트
 public protocol TCPServerDelegate: AnyObject, Sendable {

--- a/Projects/Shared/Sources/Network/Connection/UDPSocket.swift
+++ b/Projects/Shared/Sources/Network/Connection/UDPSocket.swift
@@ -2,7 +2,7 @@ import Foundation
 import Network
 import os
 
-private let logger = Logger(subsystem: "com.snap.shared", category: "UDPSocket")
+private let logger = NetworkLogger.udp
 
 /// UDP 소켓 델리게이트
 public protocol UDPSocketDelegate: AnyObject, Sendable {

--- a/Projects/Shared/Sources/Network/NetworkLogger.swift
+++ b/Projects/Shared/Sources/Network/NetworkLogger.swift
@@ -1,0 +1,111 @@
+import Foundation
+import os
+
+/// 네트워크 로깅 유틸리티
+/// 구조화된 로깅과 카테고리별 필터링 지원
+public enum NetworkLogger {
+    // MARK: - Loggers
+
+    /// TCP 관련 로깅
+    public static let tcp = Logger(subsystem: subsystem, category: "Network.TCP")
+
+    /// UDP 관련 로깅
+    public static let udp = Logger(subsystem: subsystem, category: "Network.UDP")
+
+    /// Bonjour 서비스 검색 로깅
+    public static let bonjour = Logger(subsystem: subsystem, category: "Network.Bonjour")
+
+    /// TLS/DTLS 보안 로깅
+    public static let security = Logger(subsystem: subsystem, category: "Security.TLS")
+
+    /// 일반 네트워크 로깅
+    public static let general = Logger(subsystem: subsystem, category: "Network")
+
+    // MARK: - Configuration
+
+    private static let subsystem = "com.snap.network"
+
+    // MARK: - Convenience Methods
+
+    /// 연결 상태 변경 로깅
+    public static func logConnectionStateChange(
+        from oldState: String,
+        to newState: String,
+        host: String? = nil,
+        port: UInt16? = nil
+    ) {
+        if let host, let port {
+            tcp.info("Connection state: \(oldState) → \(newState) [\(host):\(port)]")
+        } else {
+            tcp.info("Connection state: \(oldState) → \(newState)")
+        }
+    }
+
+    /// 패킷 전송 로깅
+    public static func logPacketSent(
+        type: String,
+        size: Int,
+        protocol: String = "TCP"
+    ) {
+        let logger = `protocol` == "UDP" ? udp : tcp
+        logger.debug("Sent \(type) packet (\(size) bytes)")
+    }
+
+    /// 패킷 수신 로깅
+    public static func logPacketReceived(
+        type: String,
+        size: Int,
+        protocol: String = "TCP"
+    ) {
+        let logger = `protocol` == "UDP" ? udp : tcp
+        logger.debug("Received \(type) packet (\(size) bytes)")
+    }
+
+    /// 패킷 전송 실패 로깅
+    public static func logPacketSendFailed(
+        type: String,
+        error: Error,
+        protocol: String = "TCP"
+    ) {
+        let logger = `protocol` == "UDP" ? udp : tcp
+        logger.error("Failed to send \(type) packet: \(error.localizedDescription)")
+    }
+
+    /// 연결 에러 로깅
+    public static func logConnectionError(_ error: Error, context: String? = nil) {
+        if let context {
+            tcp.error("Connection error [\(context)]: \(error.localizedDescription)")
+        } else {
+            tcp.error("Connection error: \(error.localizedDescription)")
+        }
+    }
+
+    /// 타임아웃 로깅
+    public static func logTimeout(type: String, duration: TimeInterval) {
+        tcp.warning("\(type) timeout after \(String(format: "%.1f", duration)) seconds")
+    }
+
+    /// Bonjour 서비스 발견 로깅
+    public static func logServiceDiscovered(name: String, host: String, port: UInt16) {
+        bonjour.info("Discovered service: \(name) at \(host):\(port)")
+    }
+
+    /// Bonjour 서비스 소실 로깅
+    public static func logServiceLost(name: String) {
+        bonjour.info("Lost service: \(name)")
+    }
+
+    /// TLS 핸드셰이크 로깅
+    public static func logTLSHandshake(success: Bool, host: String) {
+        if success {
+            security.info("TLS handshake successful with \(host)")
+        } else {
+            security.warning("TLS handshake failed with \(host)")
+        }
+    }
+
+    /// 네트워크 인터페이스 변경 로깅
+    public static func logNetworkInterfaceChange(from: String, to: String) {
+        general.info("Network interface changed: \(from) → \(to)")
+    }
+}


### PR DESCRIPTION
## Summary
- NetworkLogger 유틸리티 클래스 추가로 네트워크 로깅 중앙화
- TCP, UDP, Bonjour, Security 카테고리별 로거 제공
- 연결 상태 변화, 패킷 전송, 에러, 타임아웃 등 편의 메서드 추가
- 기존 네트워크 파일들의 로거를 NetworkLogger로 통일

## Test plan
- [x] iOS 빌드 성공 확인
- [x] macOS 빌드 성공 확인
- [ ] 네트워크 연결 시 로그 출력 확인

Close #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)