### PR TITLE
[Refactor]: 에러 핸들링 패턴 통일

### DIFF
--- a/Projects/App/Sources/Core/ErrorHandling/ErrorBanner.swift
+++ b/Projects/App/Sources/Core/ErrorHandling/ErrorBanner.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+
+/// 에러 배너 뷰
+///
+/// 화면 하단에 표시되는 에러 알림 배너입니다.
+/// 닫기 버튼과 선택적 재시도 버튼을 제공합니다.
+public struct ErrorBanner: View {
+    let error: AppError
+    let onDismiss: () -> Void
+    let onRetry: (() -> Void)?
+
+    public init(
+        error: AppError,
+        onDismiss: @escaping () -> Void,
+        onRetry: (() -> Void)? = nil
+    ) {
+        self.error = error
+        self.onDismiss = onDismiss
+        self.onRetry = error.canRetry ? onRetry : nil
+    }
+
+    public var body: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 12) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.title2)
+                    .foregroundStyle(.white)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(error.title)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.white)
+
+                    Text(error.userMessage)
+                        .font(.caption)
+                        .foregroundStyle(.white.opacity(0.9))
+                        .lineLimit(2)
+                }
+
+                Spacer()
+
+                Button(action: onDismiss) {
+                    Image(systemName: "xmark")
+                        .font(.body.weight(.medium))
+                        .foregroundStyle(.white.opacity(0.8))
+                }
+            }
+
+            if let onRetry {
+                HStack(spacing: 12) {
+                    Spacer()
+
+                    if error.shouldOpenSettings {
+                        Button("설정 열기") {
+                            if let url = URL(string: UIApplication.openSettingsURLString) {
+                                UIApplication.shared.open(url)
+                            }
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .tint(.white)
+                    }
+
+                    Button("다시 시도") {
+                        onRetry()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .tint(.white)
+                }
+            } else if error.shouldOpenSettings {
+                HStack {
+                    Spacer()
+                    Button("설정 열기") {
+                        if let url = URL(string: UIApplication.openSettingsURLString) {
+                            UIApplication.shared.open(url)
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .tint(.white)
+                }
+            }
+        }
+        .padding()
+        .background(.red.gradient)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.2), radius: 8, y: 4)
+    }
+}
+
+/// View modifier for displaying error banners
+public struct ErrorBannerModifier: ViewModifier {
+    let error: AppError?
+    let onDismiss: () -> Void
+    let onRetry: (() -> Void)?
+
+    public func body(content: Content) -> some View {
+        content
+            .overlay(alignment: .bottom) {
+                if let error {
+                    ErrorBanner(
+                        error: error,
+                        onDismiss: onDismiss,
+                        onRetry: onRetry
+                    )
+                    .padding()
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+            }
+            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: error != nil)
+    }
+}
+
+public extension View {
+    /// 에러 배너를 표시하는 modifier
+    func errorBanner(
+        _ error: AppError?,
+        onDismiss: @escaping () -> Void,
+        onRetry: (() -> Void)? = nil
+    ) -> some View {
+        modifier(ErrorBannerModifier(error: error, onDismiss: onDismiss, onRetry: onRetry))
+    }
+}

--- a/Projects/App/Sources/Core/ErrorHandling/ErrorHandling+TCA.swift
+++ b/Projects/App/Sources/Core/ErrorHandling/ErrorHandling+TCA.swift
@@ -1,0 +1,98 @@
+import ComposableArchitecture
+
+/// TCA용 AppError AlertState 변환 유틸리티
+public extension AppError {
+    /// AppError를 TCA AlertState로 변환
+    func toAlertState<AlertAction: Equatable>(
+        dismiss: AlertAction,
+        retry: AlertAction? = nil,
+        openSettings: AlertAction? = nil
+    ) -> AlertState<AlertAction> {
+        var buttons: [ButtonState<AlertAction>] = []
+
+        // 재시도 버튼 (가능한 경우)
+        if canRetry, let retry {
+            buttons.append(
+                ButtonState(action: retry) {
+                    TextState("다시 시도")
+                }
+            )
+        }
+
+        // 설정 열기 버튼 (권한 에러인 경우)
+        if shouldOpenSettings, let openSettings {
+            buttons.append(
+                ButtonState(action: openSettings) {
+                    TextState("설정 열기")
+                }
+            )
+        }
+
+        // 닫기 버튼 (항상 포함)
+        buttons.append(
+            ButtonState(role: .cancel, action: dismiss) {
+                TextState("확인")
+            }
+        )
+
+        return AlertState {
+            TextState(title)
+        } actions: {
+            for button in buttons {
+                button
+            }
+        } message: {
+            TextState(userMessage)
+        }
+    }
+
+    /// 간단한 에러 Alert (닫기만 가능)
+    func toSimpleAlertState<AlertAction: Equatable>(
+        dismiss: AlertAction
+    ) -> AlertState<AlertAction> {
+        AlertState {
+            TextState(title)
+        } actions: {
+            ButtonState(role: .cancel, action: dismiss) {
+                TextState("확인")
+            }
+        } message: {
+            TextState(userMessage)
+        }
+    }
+}
+
+/// ConnectionError를 AppError로 변환
+public extension ConnectionError {
+    /// ConnectionError를 AppError로 변환
+    var toAppError: AppError {
+        switch self {
+        case .discoveryFailed:
+            return .connection(.discoveryFailed)
+        case .connectionFailed:
+            return .connection(.connectionFailed)
+        case .connectionLost:
+            return .connection(.connectionLost)
+        case .timeout:
+            return .connection(.timeout)
+        case .pairingFailed:
+            return .connection(.pairingFailed)
+        case .serverError(let detail), .protocolError(let detail):
+            return .connection(.serverError(detail))
+        case .disconnected:
+            return .connection(.connectionLost)
+        }
+    }
+}
+
+/// 공통 에러 Alert Action 프로토콜
+public protocol ErrorAlertAction: Equatable {
+    static var dismissError: Self { get }
+    static var retryError: Self? { get }
+    static var openSettings: Self? { get }
+}
+
+public extension ErrorAlertAction {
+    static var retryError: Self? { nil }
+    static var openSettings: Self? { nil }
+}

--- a/Projects/App/Sources/Features/Connection/ConnectionFeature.swift
+++ b/Projects/App/Sources/Features/Connection/ConnectionFeature.swift
@@ -9,7 +9,7 @@ public struct ConnectionFeature: Sendable {
         public var status: ConnectionStatus = .disconnected
         public var discoveredDevices: IdentifiedArrayOf<Device> = []
         public var connectedDevice: Device?
-        public var lastError: ConnectionError?
+        public var lastError: AppError?
         public var latency: TimeInterval = 0
         public var signalStrength: SignalStrength = .unknown
 
@@ -68,7 +68,7 @@ public struct ConnectionFeature: Sendable {
         case setAutoReconnect(Bool)
 
         // Error
-        case errorOccurred(ConnectionError)
+        case errorOccurred(AppError)
         case clearError
     }
 
@@ -143,8 +143,8 @@ public struct ConnectionFeature: Sendable {
                 case .deviceLost(let name):
                     state.discoveredDevices.removeAll { $0.name == name }
 
-                case .error(let message):
-                    state.lastError = .discoveryFailed(message)
+                case .error:
+                    state.lastError = .connection(.discoveryFailed)
                 }
                 return .none
 
@@ -207,8 +207,8 @@ public struct ConnectionFeature: Sendable {
                     state.isPairingRequired = false
                     state.pairingPinCode = ""
 
-                    if let message = errorMessage {
-                        state.lastError = .connectionLost(message)
+                    if errorMessage != nil {
+                        state.lastError = .connection(.connectionLost)
                     }
 
                     // 자동 재연결 시도
@@ -230,11 +230,11 @@ public struct ConnectionFeature: Sendable {
                     case .nowPlayingInfo(let info):
                         return .send(.nowPlayingInfoReceived(info))
                     case .error(let message):
-                        state.lastError = .serverError(message)
+                        state.lastError = .connection(.serverError(message))
                     }
 
-                case .error(let message):
-                    state.lastError = .connectionFailed(message)
+                case .error:
+                    state.lastError = .connection(.connectionFailed)
 
                     // 연결 중 에러 발생 시 재연결 시도
                     if case .connecting(let device) = state.status {
@@ -264,12 +264,12 @@ public struct ConnectionFeature: Sendable {
                     state.pairingPinCode = ""
                     state.reconnectAttempt = 0
 
-                case .pairingResult(let success, let message):
+                case .pairingResult(let success, _):
                     if success {
                         state.isPairingRequired = false
                         state.pairingPinCode = ""
                     } else {
-                        state.lastError = .pairingFailed(message)
+                        state.lastError = .connection(.pairingFailed)
                         state.pairingPinCode = ""
                     }
                 }
@@ -278,7 +278,7 @@ public struct ConnectionFeature: Sendable {
             // MARK: - Reconnection
 
             case .attemptReconnect:
-                guard case .reconnecting(let device, let attempt) = state.status else {
+                guard case .reconnecting(_, let attempt) = state.status else {
                     return .none
                 }
 

--- a/Projects/App/Sources/Features/LaserPointer/LaserPointerFeature.swift
+++ b/Projects/App/Sources/Features/LaserPointer/LaserPointerFeature.swift
@@ -57,15 +57,8 @@ public struct LaserPointerFeature {
 
             case .startPointing:
                 guard motionClient.isAvailable() else {
-                    state.alert = AlertState {
-                        TextState("오류")
-                    } actions: {
-                        ButtonState(action: .dismiss) {
-                            TextState("확인")
-                        }
-                    } message: {
-                        TextState("자이로스코프를 사용할 수 없습니다")
-                    }
+                    state.alert = AppError.general("자이로스코프를 사용할 수 없습니다")
+                        .toSimpleAlertState(dismiss: .dismiss)
                     return .none
                 }
 
@@ -116,15 +109,8 @@ public struct LaserPointerFeature {
                     }
 
                 case .error(let message):
-                    state.alert = AlertState {
-                        TextState("오류")
-                    } actions: {
-                        ButtonState(action: .dismiss) {
-                            TextState("확인")
-                        }
-                    } message: {
-                        TextState(message)
-                    }
+                    state.alert = AppError.general(message)
+                        .toSimpleAlertState(dismiss: .dismiss)
                     state.isActive = false
                 }
                 return .none

--- a/Projects/App/Sources/Features/VoiceTyping/VoiceTypingFeature.swift
+++ b/Projects/App/Sources/Features/VoiceTyping/VoiceTypingFeature.swift
@@ -90,18 +90,8 @@ public struct VoiceTypingFeature {
 
             case .startRecording:
                 guard state.authorizationStatus == .authorized else {
-                    state.alert = AlertState {
-                        TextState("권한 필요")
-                    } actions: {
-                        ButtonState(action: .openSettings) {
-                            TextState("설정 열기")
-                        }
-                        ButtonState(role: .cancel, action: .dismiss) {
-                            TextState("취소")
-                        }
-                    } message: {
-                        TextState("음성 인식 권한이 필요합니다. 설정에서 권한을 허용해주세요.")
-                    }
+                    state.alert = AppError.permission(.speechRecognition)
+                        .toAlertState(dismiss: .dismiss, openSettings: .openSettings)
                     return .none
                 }
 
@@ -128,28 +118,14 @@ public struct VoiceTypingFeature {
                     }
 
                 case .error(let message):
-                    state.alert = AlertState {
-                        TextState("오류")
-                    } actions: {
-                        ButtonState(action: .dismiss) {
-                            TextState("확인")
-                        }
-                    } message: {
-                        TextState(message)
-                    }
+                    state.alert = AppError.general(message)
+                        .toSimpleAlertState(dismiss: .dismiss)
                     state.isRecording = false
 
                 case .availabilityChanged(let available):
                     if !available {
-                        state.alert = AlertState {
-                            TextState("오류")
-                        } actions: {
-                            ButtonState(action: .dismiss) {
-                                TextState("확인")
-                            }
-                        } message: {
-                            TextState("음성 인식을 사용할 수 없습니다")
-                        }
+                        state.alert = AppError.speech(.notAvailable)
+                            .toSimpleAlertState(dismiss: .dismiss)
                         state.isRecording = false
                     }
                 }


### PR DESCRIPTION
## Summary
- ErrorBanner 컴포넌트 추가: 화면 하단에 표시되는 에러 알림 배너
- AppError를 AlertState로 변환하는 TCA 유틸리티 추가
- ConnectionFeature: ConnectionError 대신 AppError 사용으로 통일
- VoiceTypingFeature: AppError 기반 에러 처리로 변경
- LaserPointerFeature: AppError 기반 에러 처리로 변경

## Changes
- `ErrorBanner.swift`: 에러 배너 뷰 컴포넌트 및 view modifier
- `ErrorHandling+TCA.swift`: AppError → AlertState 변환 유틸리티
- Feature 파일들의 에러 핸들링 코드 리팩토링

## Test plan
- [x] iOS 빌드 성공 확인
- [x] macOS 빌드 성공 확인
- [ ] 에러 발생 시 Alert 정상 표시 확인

Close #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)