### PR TITLE
[Design]: VoiceOver 접근성 레이블 추가

### DIFF
--- a/Projects/App/Sources/Features/Productivity/ProductivityView.swift
+++ b/Projects/App/Sources/Features/Productivity/ProductivityView.swift
@@ -130,6 +130,7 @@ public struct ProductivityView: View {
                 }
                 .buttonStyle(.plain)
                 .pressEffect()
+                .accessibilityLabel("Mac 받아쓰기 시작")
 
                 Spacer()
             }
@@ -462,6 +463,8 @@ struct SiriButton: View {
             }
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(isActive ? "Siri 활성화됨" : "Siri 시작")
+        .accessibilityHint("탭하여 Mac의 Siri를 제어합니다")
         .onChange(of: isActive) { _, newValue in
             if newValue {
                 withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
@@ -503,6 +506,7 @@ struct WindowSnapButton: View {
         }
         .buttonStyle(.plain)
         .pressEffect()
+        .accessibilityLabel("윈도우를 \(label)으로 스냅")
     }
 }
 

--- a/Projects/App/Sources/Features/Trackpad/TrackpadView.swift
+++ b/Projects/App/Sources/Features/Trackpad/TrackpadView.swift
@@ -195,6 +195,8 @@ struct VoiceTypingButton: View {
         .pressEffect()
         .disabled(!isAuthorized)
         .opacity(isAuthorized ? 1 : 0.5)
+        .accessibilityLabel(isRecording ? "음성 입력 중지" : "음성 입력 시작")
+        .accessibilityHint(isRecording ? "탭하여 음성 입력을 중지합니다" : "탭하여 음성으로 텍스트를 입력합니다")
     }
 }
 
@@ -722,6 +724,7 @@ struct ClickButton: View {
                     }
             )
             .accessibilityLabel(isPrimary ? "왼쪽 클릭" : "오른쪽 클릭")
+            .accessibilityHint("길게 눌러 클릭을 유지할 수 있습니다")
     }
 }
 

--- a/Projects/App/Sources/Views/AppView.swift
+++ b/Projects/App/Sources/Views/AppView.swift
@@ -15,6 +15,21 @@ public struct AppView: View {
         return false
     }
 
+    private var connectionAccessibilityLabel: String {
+        switch store.connection.status {
+        case .disconnected:
+            return "연결 끊김"
+        case .discovering:
+            return "기기 검색 중"
+        case .connecting(let device):
+            return "\(device.name)에 연결 중"
+        case .connected(let device):
+            return "\(device.name)에 연결됨"
+        case .reconnecting(_, let attempt):
+            return "재연결 시도 중 (\(attempt)회)"
+        }
+    }
+
     public var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
@@ -76,6 +91,8 @@ public struct AppView: View {
                     } label: {
                         connectionIcon
                     }
+                    .accessibilityLabel(connectionAccessibilityLabel)
+                    .accessibilityHint("탭하여 연결 설정을 엽니다")
                 }
 
                 ToolbarItem(placement: .topBarTrailing) {
@@ -88,6 +105,7 @@ public struct AppView: View {
                         Image(systemName: "gearshape")
                             .foregroundStyle(SnapColors.textSecondary)
                     }
+                    .accessibilityLabel("설정")
                 }
             }
             .toolbarBackground(SnapColors.background, for: .navigationBar)
@@ -177,6 +195,25 @@ struct ConnectionStatusBar: View {
         .padding(.horizontal, SnapSpacing.lg)
         .padding(.vertical, SnapSpacing.sm)
         .background(backgroundColor)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var accessibilityLabel: String {
+        var label = statusMessage
+        if status.isConnected {
+            label += ", 신호 강도: \(signalStrengthLabel)"
+        }
+        return label
+    }
+
+    private var signalStrengthLabel: String {
+        switch signalStrength {
+        case .strong: return "강함"
+        case .moderate: return "보통"
+        case .weak: return "약함"
+        case .unknown: return "알 수 없음"
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- TrackpadView: 음성 입력, 클릭 버튼 접근성 레이블/힌트 추가
- KeyboardView: 기존 접근성 구현 확인 (이미 구현됨)
- MediaView: 기존 접근성 구현 확인 (이미 구현됨)
- AppView: 연결 상태 버튼, 설정 버튼 접근성 레이블 추가
- ConnectionStatusBar: 접근성 요소 결합 및 신호 강도 설명 추가
- ProductivityView: Siri, 받아쓰기, 윈도우 스냅 버튼 접근성 레이블 추가

## Test plan
- [x] iOS 빌드 성공 확인
- [ ] VoiceOver 활성화 후 모든 컨트롤 탐색 가능 확인
- [ ] 접근성 레이블이 적절히 읽히는지 확인

Close #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)