### PR TITLE
[Refactor]: 햅틱 피드백 코드 중복 제거

### DIFF
--- a/Projects/App/Sources/Features/Presenter/PresenterView.swift
+++ b/Projects/App/Sources/Features/Presenter/PresenterView.swift
@@ -47,7 +47,9 @@ public struct PresenterSection: View {
         .clipShape(RoundedRectangle(cornerRadius: 16))
         .onChange(of: store.isOvertime) { _, isOvertime in
             if isOvertime {
-                triggerHaptic(.error)
+                Task { @MainActor in
+                    HapticManager.shared.error()
+                }
             }
         }
     }
@@ -95,7 +97,9 @@ public struct PresenterSection: View {
             // Start Button
             Button {
                 store.send(.startPresentation)
-                triggerHaptic(.medium)
+                Task { @MainActor in
+                    HapticManager.shared.mediumImpact()
+                }
             } label: {
                 HStack {
                     Image(systemName: "play.fill")
@@ -183,7 +187,9 @@ public struct PresenterSection: View {
                 color: .secondary
             ) {
                 store.send(.previousSlide)
-                triggerHaptic(.light)
+                Task { @MainActor in
+                    HapticManager.shared.lightImpact()
+                }
             }
 
             // Next Slide
@@ -193,7 +199,9 @@ public struct PresenterSection: View {
                 color: .accentColor
             ) {
                 store.send(.nextSlide)
-                triggerHaptic(.light)
+                Task { @MainActor in
+                    HapticManager.shared.lightImpact()
+                }
             }
         }
         .frame(height: 120)
@@ -209,7 +217,9 @@ public struct PresenterSection: View {
                 isActive: store.isScreenBlank
             ) {
                 store.send(.toggleScreenBlank)
-                triggerHaptic(.medium)
+                Task { @MainActor in
+                    HapticManager.shared.mediumImpact()
+                }
             }
 
             // Timer Pause/Resume
@@ -223,7 +233,9 @@ public struct PresenterSection: View {
                 } else {
                     store.send(.startTimer)
                 }
-                triggerHaptic(.light)
+                Task { @MainActor in
+                    HapticManager.shared.lightImpact()
+                }
             }
 
             // End Presentation
@@ -234,21 +246,11 @@ public struct PresenterSection: View {
                 isDestructive: true
             ) {
                 store.send(.endPresentation)
-                triggerHaptic(.medium)
+                Task { @MainActor in
+                    HapticManager.shared.mediumImpact()
+                }
             }
         }
-    }
-
-    // MARK: - Haptic Feedback
-
-    private func triggerHaptic(_ style: UIImpactFeedbackGenerator.FeedbackStyle) {
-        let generator = UIImpactFeedbackGenerator(style: style)
-        generator.impactOccurred()
-    }
-
-    private func triggerHaptic(_ type: UINotificationFeedbackGenerator.FeedbackType) {
-        let generator = UINotificationFeedbackGenerator()
-        generator.notificationOccurred(type)
     }
 }
 
@@ -390,7 +392,9 @@ public struct PresenterFullScreenView: View {
                             .contentShape(Rectangle())
                             .onTapGesture {
                                 store.send(.previousSlide)
-                                triggerHaptic(.light)
+                                Task { @MainActor in
+                                    HapticManager.shared.lightImpact()
+                                }
                             }
 
                         // Next (Right Half)
@@ -398,7 +402,9 @@ public struct PresenterFullScreenView: View {
                             .contentShape(Rectangle())
                             .onTapGesture {
                                 store.send(.nextSlide)
-                                triggerHaptic(.light)
+                                Task { @MainActor in
+                                    HapticManager.shared.lightImpact()
+                                }
                             }
                     }
                     .frame(height: geometry.size.height * 0.5)
@@ -444,11 +450,6 @@ public struct PresenterFullScreenView: View {
             }
         }
         .statusBarHidden()
-    }
-
-    private func triggerHaptic(_ style: UIImpactFeedbackGenerator.FeedbackStyle) {
-        let generator = UIImpactFeedbackGenerator(style: style)
-        generator.impactOccurred()
     }
 }
 

--- a/Projects/App/Sources/Features/QuickLaunch/QuickLaunchView.swift
+++ b/Projects/App/Sources/Features/QuickLaunch/QuickLaunchView.swift
@@ -1,6 +1,5 @@
 import ComposableArchitecture
 import SwiftUI
-import UIKit
 
 public struct QuickLaunchView: View {
     @Bindable var store: StoreOf<QuickLaunchFeature>
@@ -100,7 +99,9 @@ struct QuickLaunchButton: View {
 
     var body: some View {
         Button {
-            triggerHaptic()
+            Task { @MainActor in
+                HapticManager.shared.mediumImpact()
+            }
             onTap()
         } label: {
             content
@@ -174,11 +175,6 @@ struct QuickLaunchButton: View {
                 .foregroundStyle(.white, .red)
         }
         .offset(x: 8, y: -8)
-    }
-
-    private func triggerHaptic() {
-        let generator = UIImpactFeedbackGenerator(style: .medium)
-        generator.impactOccurred()
     }
 }
 

--- a/Projects/App/Sources/Features/ShortsRemote/ShortsRemoteView.swift
+++ b/Projects/App/Sources/Features/ShortsRemote/ShortsRemoteView.swift
@@ -1,6 +1,5 @@
 import ComposableArchitecture
 import SwiftUI
-import UIKit
 
 public struct ShortsRemoteView: View {
     @Bindable var store: StoreOf<ShortsRemoteFeature>
@@ -210,11 +209,15 @@ struct SwipeNavigationArea: View {
 
                         if offset < -threshold || velocity < -100 {
                             // Swipe up -> next video
-                            triggerHaptic()
+                            Task { @MainActor in
+                                HapticManager.shared.mediumImpact()
+                            }
                             onSwipeUp()
                         } else if offset > threshold || velocity > 100 {
                             // Swipe down -> previous video
-                            triggerHaptic()
+                            Task { @MainActor in
+                                HapticManager.shared.mediumImpact()
+                            }
                             onSwipeDown()
                         }
 
@@ -228,11 +231,6 @@ struct SwipeNavigationArea: View {
         }
         .frame(height: 280)
     }
-
-    private func triggerHaptic() {
-        let generator = UIImpactFeedbackGenerator(style: .medium)
-        generator.impactOccurred()
-    }
 }
 
 // MARK: - Shorts Control Button
@@ -245,7 +243,9 @@ struct ShortsControlButton: View {
 
     var body: some View {
         Button {
-            triggerHaptic()
+            Task { @MainActor in
+                HapticManager.shared.lightImpact()
+            }
             action()
         } label: {
             VStack(spacing: 6) {
@@ -263,11 +263,6 @@ struct ShortsControlButton: View {
             .foregroundStyle(.primary)
         }
         .buttonStyle(.plain)
-    }
-
-    private func triggerHaptic() {
-        let generator = UIImpactFeedbackGenerator(style: .light)
-        generator.impactOccurred()
     }
 }
 
@@ -440,10 +435,14 @@ struct CompactSwipeArea: View {
                 }
                 .onEnded { _ in
                     if offset < -threshold {
-                        triggerHaptic()
+                        Task { @MainActor in
+                            HapticManager.shared.mediumImpact()
+                        }
                         onSwipeUp()
                     } else if offset > threshold {
-                        triggerHaptic()
+                        Task { @MainActor in
+                            HapticManager.shared.mediumImpact()
+                        }
                         onSwipeDown()
                     }
                     withAnimation(.spring(response: 0.3)) {
@@ -451,11 +450,6 @@ struct CompactSwipeArea: View {
                     }
                 }
         )
-    }
-
-    private func triggerHaptic() {
-        let generator = UIImpactFeedbackGenerator(style: .medium)
-        generator.impactOccurred()
     }
 }
 
@@ -468,7 +462,9 @@ struct CompactControlButton: View {
 
     var body: some View {
         Button {
-            triggerHaptic()
+            Task { @MainActor in
+                HapticManager.shared.lightImpact()
+            }
             action()
         } label: {
             Image(systemName: icon)
@@ -481,11 +477,6 @@ struct CompactControlButton: View {
                 .foregroundStyle(isHighlighted ? Color.accentColor : .primary)
         }
         .buttonStyle(.plain)
-    }
-
-    private func triggerHaptic() {
-        let generator = UIImpactFeedbackGenerator(style: .light)
-        generator.impactOccurred()
     }
 }
 


### PR DESCRIPTION
## Summary
- 여러 View에서 중복 정의된 `triggerHaptic` 함수를 제거하고 `HapticManager.shared` 사용으로 통일
- 불필요한 `import UIKit` 제거

## 변경 파일
- `QuickLaunchView.swift`: 로컬 triggerHaptic 제거
- `ShortsRemoteView.swift`: 4개 컴포넌트의 로컬 triggerHaptic 제거
- `PresenterView.swift`: 2개 View의 로컬 triggerHaptic 제거

## Test plan
- [x] `tuist build App` 통과

Close #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)