### PR TITLE
[Fix]: HapticManager 설정 기반 강도 조절 및 on/off 기능 (#97)

### DIFF
--- a/Projects/App/Sources/DesignSystem/HapticManager.swift
+++ b/Projects/App/Sources/DesignSystem/HapticManager.swift
@@ -15,6 +15,36 @@ public final class HapticManager {
     private let selectionGenerator = UISelectionFeedbackGenerator()
     private let notification = UINotificationFeedbackGenerator()
 
+    // MARK: - Settings
+
+    /// 햅틱 활성화 여부 (설정에서 "끔"이 아닌 경우)
+    public var isEnabled: Bool {
+        hapticIntensity != 0
+    }
+
+    /// 현재 햅틱 강도 설정 (0: 끔, 1: 약하게, 2: 보통, 3: 강하게)
+    private var hapticIntensity: Int {
+        let value = UserDefaults.standard.integer(forKey: "hapticIntensity")
+        // UserDefaults에 값이 없으면 0을 반환하므로, 기본값 2(보통)로 설정
+        // 단, 사용자가 명시적으로 0(끔)을 선택한 경우는 0 유지
+        return UserDefaults.standard.object(forKey: "hapticIntensity") == nil ? 2 : value
+    }
+
+    /// 설정된 강도에 따른 intensity 배율
+    private var intensityMultiplier: CGFloat {
+        switch hapticIntensity {
+        case 1: return 0.5   // 약하게
+        case 2: return 1.0   // 보통
+        case 3: return 1.0   // 강하게 (더 강한 스타일 사용)
+        default: return 1.0
+        }
+    }
+
+    /// 강하게 설정 시 더 강한 스타일 사용 여부
+    private var useStrongerStyle: Bool {
+        hapticIntensity == 3
+    }
+
     private init() {
         // 미리 준비하여 지연 최소화
         prepareAll()
@@ -37,45 +67,56 @@ public final class HapticManager {
 
     /// 가벼운 임팩트 (버튼 탭)
     public func lightImpact() {
-        impactLight.impactOccurred()
-        impactLight.prepare()
+        guard isEnabled else { return }
+        let generator = useStrongerStyle ? impactMedium : impactLight
+        generator.impactOccurred(intensity: intensityMultiplier)
+        generator.prepare()
     }
 
     /// 중간 임팩트 (토글, 스위치)
     public func mediumImpact() {
-        impactMedium.impactOccurred()
-        impactMedium.prepare()
+        guard isEnabled else { return }
+        let generator = useStrongerStyle ? impactHeavy : impactMedium
+        generator.impactOccurred(intensity: intensityMultiplier)
+        generator.prepare()
     }
 
     /// 강한 임팩트 (중요한 액션)
     public func heavyImpact() {
-        impactHeavy.impactOccurred()
-        impactHeavy.prepare()
+        guard isEnabled else { return }
+        let generator = useStrongerStyle ? impactRigid : impactHeavy
+        generator.impactOccurred(intensity: intensityMultiplier)
+        generator.prepare()
     }
 
     /// 부드러운 임팩트 (슬라이더)
     public func softImpact() {
-        impactSoft.impactOccurred()
-        impactSoft.prepare()
+        guard isEnabled else { return }
+        let generator = useStrongerStyle ? impactMedium : impactSoft
+        generator.impactOccurred(intensity: intensityMultiplier)
+        generator.prepare()
     }
 
     /// 단단한 임팩트 (딱딱한 터치)
     public func rigidImpact() {
-        impactRigid.impactOccurred()
+        guard isEnabled else { return }
+        impactRigid.impactOccurred(intensity: intensityMultiplier)
         impactRigid.prepare()
     }
 
     /// 커스텀 강도 임팩트
     public func impact(intensity: CGFloat, style: UIImpactFeedbackGenerator.FeedbackStyle = .medium) {
+        guard isEnabled else { return }
         let generator = UIImpactFeedbackGenerator(style: style)
         generator.prepare()
-        generator.impactOccurred(intensity: intensity)
+        generator.impactOccurred(intensity: intensity * intensityMultiplier)
     }
 
     // MARK: - Selection Feedback
 
     /// 선택 피드백 (목록 스크롤, 피커)
     public func selection() {
+        guard isEnabled else { return }
         selectionGenerator.selectionChanged()
         selectionGenerator.prepare()
     }
@@ -84,18 +125,21 @@ public final class HapticManager {
 
     /// 성공 알림
     public func success() {
+        guard isEnabled else { return }
         notification.notificationOccurred(.success)
         notification.prepare()
     }
 
     /// 경고 알림
     public func warning() {
+        guard isEnabled else { return }
         notification.notificationOccurred(.warning)
         notification.prepare()
     }
 
     /// 에러 알림
     public func error() {
+        guard isEnabled else { return }
         notification.notificationOccurred(.error)
         notification.prepare()
     }


### PR DESCRIPTION
## Summary
- HapticManager가 설정 앱의 햅틱 강도 설정을 존중하도록 수정
- 끔/약하게/보통/강하게 4단계 설정 지원
- 끔 설정 시 모든 햅틱 피드백 비활성화

## Changes
- 설정에서 읽은 `hapticIntensity` 값에 따라 동작:
  - 0 (끔): 모든 햅틱 비활성화
  - 1 (약하게): intensity 0.5 배율 적용
  - 2 (보통): 기본 intensity 1.0
  - 3 (강하게): 더 강한 스타일의 generator 사용

- 모든 햅틱 메서드에 `guard isEnabled else { return }` 추가
- 이미 존재하는 SettingsView의 햅틱 강도 설정과 연동

## Test plan
- [ ] 설정 > 햅틱 피드백에서 "끔" 선택 후 앱 내 버튼 터치 시 햅틱 없음 확인
- [ ] "약하게" 선택 시 약한 햅틱 확인
- [ ] "보통" 선택 시 일반 햅틱 확인
- [ ] "강하게" 선택 시 강한 햅틱 확인

Close #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)