### PR TITLE
[Fix]: Protobuf 메시지 버전 관리 추가

### DIFF
--- a/Projects/Shared/Sources/Network/PacketDecoder.swift
+++ b/Projects/Shared/Sources/Network/PacketDecoder.swift
@@ -1,10 +1,13 @@
 import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "com.snap.shared", category: "PacketDecoder")
 
 /// 디코딩 에러
 public enum PacketDecodingError: Error, Sendable {
     case invalidHeader
     case invalidMagic
-    case unsupportedVersion
+    case unsupportedVersion(received: UInt8, expected: UInt8)
     case unknownMessageType
     case payloadTooShort
     case decodingFailed(Error)
@@ -112,10 +115,26 @@ public enum PacketDecoder {
     private static let decoder = JSONDecoder()
 
     /// 데이터에서 패킷 디코딩
+    /// - Parameter data: 패킷 데이터
+    /// - Returns: 디코딩된 패킷
+    /// - Throws: PacketDecodingError
+    /// - Note: 버전 불일치 시 경고 로깅 후 처리를 계속합니다 (하위 호환성)
     public static func decode(_ data: Data) throws -> DecodedPacket {
         // 헤더 파싱
         guard let header = PacketHeader(data: data) else {
             throw PacketDecodingError.invalidHeader
+        }
+
+        // 버전 불일치 경고 로깅 (처리는 계속)
+        if header.hasVersionMismatch {
+            logger.warning(
+                """
+                Decoding packet with version mismatch - \
+                received: \(header.version), \
+                expected: \(NetworkConstants.protocolVersion). \
+                Message type: \(String(describing: header.type))
+                """
+            )
         }
 
         // 페이로드 추출
@@ -220,5 +239,23 @@ public enum PacketDecoder {
     /// 헤더만 파싱 (페이로드 길이 확인용)
     public static func parseHeader(_ data: Data) -> PacketHeader? {
         PacketHeader(data: data)
+    }
+
+    /// 버전 호환성 확인
+    /// - Parameter version: 확인할 프로토콜 버전
+    /// - Returns: 호환 가능 여부
+    /// - Note: 현재 구현에서는 모든 버전을 허용하고 경고만 로깅합니다
+    public static func isVersionCompatible(_ version: UInt8) -> Bool {
+        if version != NetworkConstants.protocolVersion {
+            logger.info(
+                """
+                Version compatibility check - \
+                received: \(version), \
+                current: \(NetworkConstants.protocolVersion). \
+                Allowing for backward compatibility.
+                """
+            )
+        }
+        return true  // 하위 호환성을 위해 모든 버전 허용
     }
 }

--- a/Projects/Shared/Sources/Network/PacketHeader.swift
+++ b/Projects/Shared/Sources/Network/PacketHeader.swift
@@ -1,4 +1,7 @@
 import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "com.snap.shared", category: "PacketHeader")
 
 /// 패킷 헤더 구조체
 ///
@@ -27,6 +30,9 @@ public struct PacketHeader: Sendable, Equatable {
     /// 페이로드 길이
     public let payloadLength: UInt32
 
+    /// 버전 불일치 여부 (하위 호환성을 위해 처리는 계속하지만 경고 로깅)
+    public let hasVersionMismatch: Bool
+
     // MARK: - Initialization
 
     public init(
@@ -39,9 +45,12 @@ public struct PacketHeader: Sendable, Equatable {
         self.type = type
         self.timestamp = timestamp
         self.payloadLength = payloadLength
+        self.hasVersionMismatch = false
     }
 
     /// 바이트 배열에서 헤더 파싱
+    /// - Parameter data: 헤더 데이터
+    /// - Note: 버전이 다르더라도 파싱을 시도하며, 버전 불일치 시 경고 로깅
     public init?(data: Data) {
         guard data.count >= NetworkConstants.packetHeaderSize else {
             return nil
@@ -54,8 +63,16 @@ public struct PacketHeader: Sendable, Equatable {
         }
 
         let version = data[2]
-        guard version == NetworkConstants.protocolVersion else {
-            return nil
+
+        // 버전 불일치 시 경고 로깅하고 처리 계속 (하위 호환성)
+        if version != NetworkConstants.protocolVersion {
+            logger.warning(
+                """
+                Protocol version mismatch - received: \(version), \
+                expected: \(NetworkConstants.protocolVersion). \
+                Attempting to process packet anyway.
+                """
+            )
         }
 
         guard let type = MessageType(rawValue: data[3]) else {
@@ -70,6 +87,7 @@ public struct PacketHeader: Sendable, Equatable {
         self.type = type
         self.timestamp = timestamp
         self.payloadLength = payloadLength
+        self.hasVersionMismatch = version != NetworkConstants.protocolVersion
     }
 
     // MARK: - Serialization
@@ -98,9 +116,13 @@ public struct PacketHeader: Sendable, Equatable {
 
     // MARK: - Validation
 
-    /// 헤더 유효성 검사
+    /// 헤더 유효성 검사 (매직 넘버만 확인, 버전은 하위 호환성을 위해 무시)
     public var isValid: Bool {
-        magic == NetworkConstants.packetMagic &&
+        magic == NetworkConstants.packetMagic
+    }
+
+    /// 버전이 정확히 일치하는지 확인
+    public var isExactVersionMatch: Bool {
         version == NetworkConstants.protocolVersion
     }
 }

--- a/Projects/Shared/Tests/PacketTests.swift
+++ b/Projects/Shared/Tests/PacketTests.swift
@@ -44,14 +44,18 @@ struct PacketHeaderTests {
         #expect(header == nil)
     }
 
-    @Test("Unsupported version returns nil")
-    func unsupportedVersion() {
+    @Test("Different version is handled gracefully with warning")
+    func differentVersionHandledGracefully() {
         var data = PacketHeader(type: .handshake, payloadLength: 0).toData()
-        // Wrong version
+        // Different version (handled gracefully for backward compatibility)
         data[2] = 0xFF
 
         let header = PacketHeader(data: data)
-        #expect(header == nil)
+        #expect(header != nil)
+        #expect(header?.version == 0xFF)
+        #expect(header?.hasVersionMismatch == true)
+        #expect(header?.isValid == true)  // Still valid (magic is correct)
+        #expect(header?.isExactVersionMatch == false)
     }
 
     @Test("Too short data returns nil")
@@ -65,6 +69,27 @@ struct PacketHeaderTests {
     func headerIsValid() {
         let header = PacketHeader(type: .mouseMove, payloadLength: 0)
         #expect(header.isValid == true)
+        #expect(header.isExactVersionMatch == true)
+        #expect(header.hasVersionMismatch == false)
+    }
+
+    @Test("Decode packet with version mismatch succeeds")
+    func decodePacketWithVersionMismatch() throws {
+        // Create packet with different version
+        var data = PacketHeader(type: .handshake, payloadLength: 0).toData()
+        data[2] = 0x02  // Different version
+
+        // Update payload length to match actual payload
+        let payload = try JSONEncoder().encode(Handshake(deviceName: "Test", deviceID: "123", protocolVersion: 2))
+        var payloadLengthBytes = Data()
+        withUnsafeBytes(of: UInt32(payload.count).littleEndian) { payloadLengthBytes.append(contentsOf: $0) }
+        data.replaceSubrange(12..<16, with: payloadLengthBytes)
+        data.append(payload)
+
+        // Decode should succeed despite version mismatch
+        let decoded = try PacketDecoder.decode(data)
+        #expect(decoded.header.hasVersionMismatch == true)
+        #expect(decoded.header.version == 0x02)
     }
 }
 


### PR DESCRIPTION
## Summary
- 버전 불일치 시 패킷 거부 대신 graceful 처리
- OSLog로 버전 불일치 경고 로깅
- `isValid` (관대한 검사) vs `isExactVersionMatch` (엄격한 검사) 분리
- 하위 호환성 유지

## Changes
- `PacketHeader.swift`: 버전 불일치 처리 로직 추가
- `PacketDecoder.swift`: 버전 호환성 체크 유틸리티 추가
- `PacketTests.swift`: 버전 불일치 처리 테스트 추가

## Test plan
- [x] `tuist test Shared` - 57개 테스트 통과

Close #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)