### PR TITLE
[Fix]: 하드코딩된 문자열 로컬라이제이션

### DIFF
--- a/Projects/App/Resources/Localizable.xcstrings
+++ b/Projects/App/Resources/Localizable.xcstrings
@@ -1,0 +1,1213 @@
+{
+  "sourceLanguage" : "ko",
+  "strings" : {
+    "tab.trackpad" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trackpad"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "트랙패드"
+          }
+        }
+      }
+    },
+    "tab.keyboard" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keyboard"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "키보드"
+          }
+        }
+      }
+    },
+    "tab.media" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Media"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미디어"
+          }
+        }
+      }
+    },
+    "tab.more" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "More"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "더보기"
+          }
+        }
+      }
+    },
+    "mode.trackpad" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trackpad"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "트랙패드"
+          }
+        }
+      }
+    },
+    "mode.laser" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laser"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "레이저"
+          }
+        }
+      }
+    },
+    "connection.disconnected" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnected"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "연결 끊김"
+          }
+        }
+      }
+    },
+    "connection.discovering" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Discovering devices"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기기 검색 중"
+          }
+        }
+      }
+    },
+    "connection.connecting %@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connecting to %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@에 연결 중"
+          }
+        }
+      }
+    },
+    "connection.connected %@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connected to %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@에 연결됨"
+          }
+        }
+      }
+    },
+    "connection.reconnecting %lld" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reconnecting (attempt %lld)"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "재연결 시도 중 (%lld회)"
+          }
+        }
+      }
+    },
+    "connection.hint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to open connection settings"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "탭하여 연결 설정을 엽니다"
+          }
+        }
+      }
+    },
+    "settings" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "설정"
+          }
+        }
+      }
+    },
+    "status.notConnected" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not Connected"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "연결 안됨"
+          }
+        }
+      }
+    },
+    "status.searching" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Searching..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "검색 중..."
+          }
+        }
+      }
+    },
+    "status.connectingTo %@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connecting to %@..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@에 연결 중..."
+          }
+        }
+      }
+    },
+    "status.connectedTo %@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connected to %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@에 연결됨"
+          }
+        }
+      }
+    },
+    "status.reconnecting %lld" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reconnecting... (%lld/3)"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "재연결 중... (%lld/3)"
+          }
+        }
+      }
+    },
+    "signal.strong" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Strong"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "강함"
+          }
+        }
+      }
+    },
+    "signal.moderate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Moderate"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "보통"
+          }
+        }
+      }
+    },
+    "signal.weak" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weak"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "약함"
+          }
+        }
+      }
+    },
+    "signal.unknown" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unknown"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "알 수 없음"
+          }
+        }
+      }
+    },
+    "signal.label %@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ", Signal strength: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ", 신호 강도: %@"
+          }
+        }
+      }
+    },
+    "connection.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connection"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "연결"
+          }
+        }
+      }
+    },
+    "connection.connectToMac" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connect to Mac"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mac에 연결"
+          }
+        }
+      }
+    },
+    "connection.ensureReceiverRunning" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Make sure Snap Receiver is running on your Mac"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mac에서 Snap Receiver가 실행 중인지 확인하세요"
+          }
+        }
+      }
+    },
+    "connection.searchingDevices" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Searching for devices..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기기 검색 중..."
+          }
+        }
+      }
+    },
+    "done" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "완료"
+          }
+        }
+      }
+    },
+    "cancel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "취소"
+          }
+        }
+      }
+    },
+    "pairing.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pairing"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "페어링"
+          }
+        }
+      }
+    },
+    "pairing.enterPin" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter PIN Code"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PIN 코드 입력"
+          }
+        }
+      }
+    },
+    "pairing.enterPinDescription %@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter the 4-digit PIN shown on %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@에 표시된\n4자리 PIN을 입력하세요"
+          }
+        }
+      }
+    },
+    "pairing.connect" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connect"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "연결"
+          }
+        }
+      }
+    },
+    "keyboard.placeholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type here..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "여기에 입력..."
+          }
+        }
+      }
+    },
+    "keyboard.textInput" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Text Input"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "텍스트 입력"
+          }
+        }
+      }
+    },
+    "keyboard.textInputHint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter text to send to Mac"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mac으로 보낼 텍스트를 입력하세요"
+          }
+        }
+      }
+    },
+    "keyboard.clearText" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear Text"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "텍스트 지우기"
+          }
+        }
+      }
+    },
+    "keyboard.key %@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ key"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 키"
+          }
+        }
+      }
+    },
+    "keyboard.locked" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Locked"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "잠김"
+          }
+        }
+      }
+    },
+    "keyboard.active" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Active"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "활성화"
+          }
+        }
+      }
+    },
+    "keyboard.inactive" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inactive"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "비활성화"
+          }
+        }
+      }
+    },
+    "keyboard.toggleHint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to toggle, double-tap to lock"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "탭하여 토글, 더블탭하여 잠금"
+          }
+        }
+      }
+    },
+    "keyboard.spaceKey" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Space Key"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스페이스 키"
+          }
+        }
+      }
+    },
+    "arrow.up" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Up Arrow"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "위쪽 화살표"
+          }
+        }
+      }
+    },
+    "arrow.down" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Down Arrow"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아래쪽 화살표"
+          }
+        }
+      }
+    },
+    "arrow.left" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Left Arrow"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "왼쪽 화살표"
+          }
+        }
+      }
+    },
+    "arrow.right" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Right Arrow"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오른쪽 화살표"
+          }
+        }
+      }
+    },
+    "settings.sensitivity" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sensitivity"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "감도"
+          }
+        }
+      }
+    },
+    "settings.trackpadSensitivity" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trackpad Sensitivity"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "트랙패드 감도"
+          }
+        }
+      }
+    },
+    "settings.scrollSensitivity" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scroll Sensitivity"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스크롤 감도"
+          }
+        }
+      }
+    },
+    "settings.laserSensitivity" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laser Pointer Sensitivity"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "레이저 포인터 감도"
+          }
+        }
+      }
+    },
+    "settings.trackpad" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trackpad"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "트랙패드"
+          }
+        }
+      }
+    },
+    "settings.naturalScrolling" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Natural Scrolling"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자연스러운 스크롤"
+          }
+        }
+      }
+    },
+    "settings.tapToClick" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to Click"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "탭하여 클릭"
+          }
+        }
+      }
+    },
+    "settings.hapticFeedback" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Haptic Feedback"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "햅틱 피드백"
+          }
+        }
+      }
+    },
+    "settings.hapticIntensity" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Haptic Intensity"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "햅틱 강도"
+          }
+        }
+      }
+    },
+    "settings.hapticFooter" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Set the intensity of haptic feedback on touch."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "터치 시 진동 피드백의 강도를 설정합니다."
+          }
+        }
+      }
+    },
+    "settings.themeColor" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Theme Color"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "테마 색상"
+          }
+        }
+      }
+    },
+    "settings.resetToDefaults" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset to Defaults"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기본값으로 재설정"
+          }
+        }
+      }
+    },
+    "haptic.off" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Off"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "끔"
+          }
+        }
+      }
+    },
+    "haptic.light" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Light"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "약하게"
+          }
+        }
+      }
+    },
+    "haptic.medium" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medium"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "보통"
+          }
+        }
+      }
+    },
+    "haptic.strong" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Strong"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "강하게"
+          }
+        }
+      }
+    },
+    "color.blue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blue"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "파랑"
+          }
+        }
+      }
+    },
+    "color.purple" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Purple"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "보라"
+          }
+        }
+      }
+    },
+    "color.pink" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pink"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "분홍"
+          }
+        }
+      }
+    },
+    "color.red" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Red"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "빨강"
+          }
+        }
+      }
+    },
+    "color.orange" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Orange"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "주황"
+          }
+        }
+      }
+    },
+    "color.yellow" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yellow"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "노랑"
+          }
+        }
+      }
+    },
+    "color.green" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Green"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "초록"
+          }
+        }
+      }
+    },
+    "color.teal" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Teal"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "청록"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Projects/App/Sources/Features/App/AppFeature.swift
+++ b/Projects/App/Sources/Features/App/AppFeature.swift
@@ -29,10 +29,10 @@ public struct AppFeature {
 
         public var title: String {
             switch self {
-            case .trackpad: return "Trackpad"
-            case .keyboard: return "Keyboard"
-            case .media: return "Media"
-            case .productivity: return "More"
+            case .trackpad: return String(localized: "tab.trackpad")
+            case .keyboard: return String(localized: "tab.keyboard")
+            case .media: return String(localized: "tab.media")
+            case .productivity: return String(localized: "tab.more")
             }
         }
 

--- a/Projects/App/Sources/Features/Keyboard/KeyboardView.swift
+++ b/Projects/App/Sources/Features/Keyboard/KeyboardView.swift
@@ -36,7 +36,7 @@ public struct KeyboardView: View {
 
     private var textInputArea: some View {
         HStack(spacing: 16) {
-            TextField("Type here...", text: $store.inputText.sending(\.textChanged))
+            TextField(String(localized: "keyboard.placeholder"), text: $store.inputText.sending(\.textChanged))
                 .textFieldStyle(.plain)
                 .font(.body)
                 .padding()
@@ -48,8 +48,8 @@ public struct KeyboardView: View {
                 )
                 .foregroundStyle(SnapColors.label)
                 .focused($isTextFieldFocused)
-                .accessibilityLabel("텍스트 입력")
-                .accessibilityHint("Mac으로 보낼 텍스트를 입력하세요")
+                .accessibilityLabel(String(localized: "keyboard.textInput"))
+                .accessibilityHint(String(localized: "keyboard.textInputHint"))
 
             Button {
                 store.send(.clearText)
@@ -59,7 +59,7 @@ public struct KeyboardView: View {
                     .foregroundStyle(SnapColors.tertiaryLabel)
             }
             .opacity(store.inputText.isEmpty ? 0 : 1)
-            .accessibilityLabel("텍스트 지우기")
+            .accessibilityLabel(String(localized: "keyboard.clearText"))
         }
     }
 
@@ -152,7 +152,7 @@ public struct KeyboardView: View {
                     )
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("스페이스 키")
+            .accessibilityLabel(String(localized: "keyboard.spaceKey"))
         }
     }
 
@@ -235,9 +235,9 @@ struct ModifierKeyButton: View {
                     onDoubleTap()
                 }
         )
-        .accessibilityLabel("\(label) 키")
-        .accessibilityValue(isLocked ? "잠김" : (isActive ? "활성화" : "비활성화"))
-        .accessibilityHint("탭하여 토글, 더블탭하여 잠금")
+        .accessibilityLabel(String(localized: "keyboard.key \(label)"))
+        .accessibilityValue(isLocked ? String(localized: "keyboard.locked") : (isActive ? String(localized: "keyboard.active") : String(localized: "keyboard.inactive")))
+        .accessibilityHint(String(localized: "keyboard.toggleHint"))
     }
 
     private var foregroundColor: Color {
@@ -293,7 +293,7 @@ struct SpecialKeyButton: View {
             .scaleEffect(isPressed ? 0.95 : 1.0)
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("\(label) 키")
+        .accessibilityLabel(String(localized: "keyboard.key \(label)"))
         .pressEvents {
             withAnimation(.spring(response: 0.2, dampingFraction: 0.6)) {
                 isPressed = true
@@ -325,10 +325,10 @@ struct ArrowKeyButton: View {
 
     private var accessibilityLabel: String {
         switch direction {
-        case .up: return "위쪽 화살표"
-        case .down: return "아래쪽 화살표"
-        case .left: return "왼쪽 화살표"
-        case .right: return "오른쪽 화살표"
+        case .up: return String(localized: "arrow.up")
+        case .down: return String(localized: "arrow.down")
+        case .left: return String(localized: "arrow.left")
+        case .right: return String(localized: "arrow.right")
         }
     }
 

--- a/Projects/App/Sources/Features/Settings/SettingsFeature.swift
+++ b/Projects/App/Sources/Features/Settings/SettingsFeature.swift
@@ -67,10 +67,10 @@ public enum HapticIntensity: Int, CaseIterable, Sendable {
 
     public var title: String {
         switch self {
-        case .off: return "끔"
-        case .light: return "약하게"
-        case .medium: return "보통"
-        case .strong: return "강하게"
+        case .off: return String(localized: "haptic.off")
+        case .light: return String(localized: "haptic.light")
+        case .medium: return String(localized: "haptic.medium")
+        case .strong: return String(localized: "haptic.strong")
         }
     }
 }
@@ -100,14 +100,14 @@ public enum AccentColor: Int, CaseIterable, Sendable {
 
     public var title: String {
         switch self {
-        case .blue: return "파랑"
-        case .purple: return "보라"
-        case .pink: return "분홍"
-        case .red: return "빨강"
-        case .orange: return "주황"
-        case .yellow: return "노랑"
-        case .green: return "초록"
-        case .teal: return "청록"
+        case .blue: return String(localized: "color.blue")
+        case .purple: return String(localized: "color.purple")
+        case .pink: return String(localized: "color.pink")
+        case .red: return String(localized: "color.red")
+        case .orange: return String(localized: "color.orange")
+        case .yellow: return String(localized: "color.yellow")
+        case .green: return String(localized: "color.green")
+        case .teal: return String(localized: "color.teal")
         }
     }
 }

--- a/Projects/App/Sources/Features/Settings/SettingsView.swift
+++ b/Projects/App/Sources/Features/Settings/SettingsView.swift
@@ -28,12 +28,14 @@ public struct SettingsView: View {
                 // Reset Section
                 resetSection
             }
-            .navigationTitle("설정")
+            .navigationTitle(Text("settings"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
-                    Button("완료") {
+                    Button {
                         onDismiss()
+                    } label: {
+                        Text("done")
                     }
                 }
             }
@@ -50,7 +52,7 @@ public struct SettingsView: View {
         Section {
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
-                    Text("트랙패드 감도")
+                    Text("settings.trackpadSensitivity")
                     Spacer()
                     Text(String(format: "%.1f", store.trackpadSensitivity))
                         .foregroundStyle(SnapColors.textSecondary)
@@ -63,12 +65,12 @@ public struct SettingsView: View {
                 )
             }
             .accessibilityElement(children: .combine)
-            .accessibilityLabel("트랙패드 감도")
+            .accessibilityLabel(String(localized: "settings.trackpadSensitivity"))
             .accessibilityValue(String(format: "%.1f", store.trackpadSensitivity))
 
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
-                    Text("스크롤 감도")
+                    Text("settings.scrollSensitivity")
                     Spacer()
                     Text(String(format: "%.1f", store.scrollSensitivity))
                         .foregroundStyle(SnapColors.textSecondary)
@@ -81,12 +83,12 @@ public struct SettingsView: View {
                 )
             }
             .accessibilityElement(children: .combine)
-            .accessibilityLabel("스크롤 감도")
+            .accessibilityLabel(String(localized: "settings.scrollSensitivity"))
             .accessibilityValue(String(format: "%.1f", store.scrollSensitivity))
 
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
-                    Text("레이저 포인터 감도")
+                    Text("settings.laserSensitivity")
                     Spacer()
                     Text(String(format: "%.1f", store.laserSensitivity))
                         .foregroundStyle(SnapColors.textSecondary)
@@ -99,10 +101,10 @@ public struct SettingsView: View {
                 )
             }
             .accessibilityElement(children: .combine)
-            .accessibilityLabel("레이저 포인터 감도")
+            .accessibilityLabel(String(localized: "settings.laserSensitivity"))
             .accessibilityValue(String(format: "%.1f", store.laserSensitivity))
         } header: {
-            Text("감도")
+            Text("settings.sensitivity")
         }
     }
 
@@ -111,17 +113,17 @@ public struct SettingsView: View {
     @ViewBuilder
     private var trackpadOptionsSection: some View {
         Section {
-            Toggle("자연스러운 스크롤", isOn: Binding(
+            Toggle(String(localized: "settings.naturalScrolling"), isOn: Binding(
                 get: { store.isNaturalScrolling },
                 set: { _ in store.send(.toggleNaturalScrolling) }
             ))
 
-            Toggle("탭하여 클릭", isOn: Binding(
+            Toggle(String(localized: "settings.tapToClick"), isOn: Binding(
                 get: { store.isTapToClick },
                 set: { _ in store.send(.toggleTapToClick) }
             ))
         } header: {
-            Text("트랙패드")
+            Text("settings.trackpad")
         }
     }
 
@@ -130,7 +132,7 @@ public struct SettingsView: View {
     @ViewBuilder
     private var hapticSection: some View {
         Section {
-            Picker("햅틱 강도", selection: Binding(
+            Picker(String(localized: "settings.hapticIntensity"), selection: Binding(
                 get: { store.hapticIntensity },
                 set: { store.send(.setHapticIntensity($0)) }
             )) {
@@ -140,9 +142,9 @@ public struct SettingsView: View {
             }
             .pickerStyle(.segmented)
         } header: {
-            Text("햅틱 피드백")
+            Text("settings.hapticFeedback")
         } footer: {
-            Text("터치 시 진동 피드백의 강도를 설정합니다.")
+            Text("settings.hapticFooter")
         }
     }
 
@@ -168,7 +170,7 @@ public struct SettingsView: View {
             }
             .padding(.vertical, 8)
         } header: {
-            Text("테마 색상")
+            Text("settings.themeColor")
         }
     }
 
@@ -182,7 +184,7 @@ public struct SettingsView: View {
             } label: {
                 HStack {
                     Spacer()
-                    Text("기본값으로 재설정")
+                    Text("settings.resetToDefaults")
                     Spacer()
                 }
             }

--- a/Projects/App/Sources/Features/Trackpad/TrackpadFeature.swift
+++ b/Projects/App/Sources/Features/Trackpad/TrackpadFeature.swift
@@ -25,8 +25,8 @@ public struct TrackpadFeature {
 
         public var title: String {
             switch self {
-            case .trackpad: return "Trackpad"
-            case .laser: return "Laser"
+            case .trackpad: return String(localized: "mode.trackpad")
+            case .laser: return String(localized: "mode.laser")
             }
         }
     }

--- a/Projects/App/Sources/Views/AppView.swift
+++ b/Projects/App/Sources/Views/AppView.swift
@@ -18,15 +18,15 @@ public struct AppView: View {
     private var connectionAccessibilityLabel: String {
         switch store.connection.status {
         case .disconnected:
-            return "연결 끊김"
+            return String(localized: "connection.disconnected")
         case .discovering:
-            return "기기 검색 중"
+            return String(localized: "connection.discovering")
         case .connecting(let device):
-            return "\(device.name)에 연결 중"
+            return String(localized: "connection.connecting \(device.name)")
         case .connected(let device):
-            return "\(device.name)에 연결됨"
+            return String(localized: "connection.connected \(device.name)")
         case .reconnecting(_, let attempt):
-            return "재연결 시도 중 (\(attempt)회)"
+            return String(localized: "connection.reconnecting \(attempt)")
         }
     }
 
@@ -92,7 +92,7 @@ public struct AppView: View {
                         connectionIcon
                     }
                     .accessibilityLabel(connectionAccessibilityLabel)
-                    .accessibilityHint("탭하여 연결 설정을 엽니다")
+                    .accessibilityHint(String(localized: "connection.hint"))
                 }
 
                 ToolbarItem(placement: .topBarTrailing) {
@@ -105,7 +105,7 @@ public struct AppView: View {
                         Image(systemName: "gearshape")
                             .foregroundStyle(SnapColors.textSecondary)
                     }
-                    .accessibilityLabel("설정")
+                    .accessibilityLabel(String(localized: "settings"))
                 }
             }
             .toolbarBackground(SnapColors.background, for: .navigationBar)
@@ -214,17 +214,17 @@ struct ConnectionStatusBar: View {
     private var accessibilityLabel: String {
         var label = statusMessage
         if status.isConnected {
-            label += ", 신호 강도: \(signalStrengthLabel)"
+            label += String(localized: "signal.label \(signalStrengthLabel)")
         }
         return label
     }
 
     private var signalStrengthLabel: String {
         switch signalStrength {
-        case .strong: return "강함"
-        case .moderate: return "보통"
-        case .weak: return "약함"
-        case .unknown: return "알 수 없음"
+        case .strong: return String(localized: "signal.strong")
+        case .moderate: return String(localized: "signal.moderate")
+        case .weak: return String(localized: "signal.weak")
+        case .unknown: return String(localized: "signal.unknown")
         }
     }
 
@@ -259,15 +259,15 @@ struct ConnectionStatusBar: View {
     private var statusMessage: String {
         switch status {
         case .disconnected:
-            "연결 안됨"
+            String(localized: "status.notConnected")
         case .discovering:
-            "검색 중..."
+            String(localized: "status.searching")
         case .connecting(let device):
-            "\(device.name)에 연결 중..."
+            String(localized: "status.connectingTo \(device.name)")
         case .connected(let device):
-            "\(device.name)에 연결됨"
+            String(localized: "status.connectedTo \(device.name)")
         case .reconnecting(_, let attempt):
-            "재연결 중... (\(attempt)/3)"
+            String(localized: "status.reconnecting \(attempt)")
         }
     }
 
@@ -373,11 +373,11 @@ struct ConnectionSheetView: View {
                 .glowAnimation(color: SnapColors.cyberBlue, isActive: true)
 
                 VStack(spacing: SnapSpacing.sm) {
-                    Text("Mac에 연결")
+                    Text("connection.connectToMac")
                         .font(SnapTypography.headlineLarge)
                         .foregroundStyle(SnapColors.textPrimary)
 
-                    Text("Mac에서 Snap Receiver가 실행 중인지 확인하세요")
+                    Text("connection.ensureReceiverRunning")
                         .font(SnapTypography.bodyMedium)
                         .foregroundStyle(SnapColors.textSecondary)
                         .multilineTextAlignment(.center)
@@ -389,7 +389,7 @@ struct ConnectionSheetView: View {
                     ProgressView()
                         .tint(SnapColors.cyberBlue)
 
-                    Text("기기 검색 중...")
+                    Text("connection.searchingDevices")
                         .font(SnapTypography.labelMedium)
                         .foregroundStyle(SnapColors.textTertiary)
                 }
@@ -398,17 +398,19 @@ struct ConnectionSheetView: View {
             }
             .padding(SnapSpacing.xl)
             .background(SnapColors.background)
-            .navigationTitle("연결")
+            .navigationTitle(Text("connection.title"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackground(SnapColors.background, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
-                    Button("완료") {
+                    Button {
                         Task { @MainActor in
                             HapticManager.shared.buttonTap()
                         }
                         onDismiss()
+                    } label: {
+                        Text("done")
                     }
                     .foregroundStyle(SnapColors.cyberBlue)
                 }
@@ -447,11 +449,11 @@ struct PairingPinView: View {
 
                 // Title
                 VStack(spacing: SnapSpacing.sm) {
-                    Text("PIN 코드 입력")
+                    Text("pairing.enterPin")
                         .font(SnapTypography.headlineLarge)
                         .foregroundStyle(SnapColors.textPrimary)
 
-                    Text("\(serverName)에 표시된\n4자리 PIN을 입력하세요")
+                    Text("pairing.enterPinDescription \(serverName)")
                         .font(SnapTypography.bodyMedium)
                         .foregroundStyle(SnapColors.textSecondary)
                         .multilineTextAlignment(.center)
@@ -502,7 +504,7 @@ struct PairingPinView: View {
                     }
                     onSubmit()
                 } label: {
-                    Text("연결")
+                    Text("pairing.connect")
                         .font(SnapTypography.labelLarge)
                         .foregroundStyle(SnapColors.background)
                         .frame(maxWidth: .infinity)
@@ -518,17 +520,19 @@ struct PairingPinView: View {
             }
             .padding(SnapSpacing.xl)
             .background(SnapColors.background)
-            .navigationTitle("페어링")
+            .navigationTitle(Text("pairing.title"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackground(SnapColors.background, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    Button("취소") {
+                    Button {
                         Task { @MainActor in
                             HapticManager.shared.buttonTap()
                         }
                         onCancel()
+                    } label: {
+                        Text("cancel")
                     }
                     .foregroundStyle(SnapColors.neonRed)
                 }


### PR DESCRIPTION
## Summary
- String Catalog (Localizable.xcstrings) 추가
- 모든 View 파일의 하드코딩된 한글 문자열을 LocalizedStringKey로 변경
- 한국어(ko) 및 영어(en) 번역 지원

## Changes
- 새 파일: `Localizable.xcstrings`
- 수정된 View 파일들: 탭 이름, 버튼, 상태 메시지 등

## Test plan
- [x] `tuist generate` 빌드 성공

Close #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)